### PR TITLE
Add lead magnet landing pages + email capture worker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Deploy Site + Worker
 
 on:
   push:
@@ -52,3 +52,17 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  deploy-worker:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy Cloudflare Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: worker

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -23,6 +23,7 @@ export default function (eleventyConfig) {
     // The following copies to `_site/images`
     eleventyConfig.addPassthroughCopy("site/images");
     eleventyConfig.addPassthroughCopy("site/css");
+    eleventyConfig.addPassthroughCopy("site/resources/files");
 
     eleventyConfig.addPlugin(syntaxHighlight);
     eleventyConfig.addPlugin(eleventyImageTransformPlugin, {

--- a/site/css/swiss-design.css
+++ b/site/css/swiss-design.css
@@ -1030,16 +1030,218 @@ html[data-theme="dark"] .newsletter-input {
   .newsletter-form {
     flex-direction: column;
   }
-  
+
   .articles-grid {
     grid-template-columns: 1fr;
   }
-  
+
   .post-header {
     padding: var(--spacing-2xl) 0 var(--spacing-lg) 0;
   }
-  
+
   .post-content {
     padding: var(--spacing-xl) 0;
+  }
+}
+
+/* ==========================================================================
+   Resource / Lead Magnet Landing Pages
+   ========================================================================== */
+
+.resource-hero {
+  padding: var(--spacing-3xl) 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.resource-hero-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-3xl);
+  align-items: start;
+}
+
+.resource-label {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.1em;
+  color: var(--accent-color);
+  margin-bottom: var(--spacing-md);
+}
+
+.resource-title {
+  font-size: 2.5rem;
+  font-weight: var(--font-weight-extrabold);
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  margin-bottom: var(--spacing-md);
+}
+
+.resource-subtitle {
+  font-size: 1.125rem;
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-xl);
+  line-height: 1.5;
+}
+
+.resource-description {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+}
+
+.preview-card {
+  background-color: var(--bg-accent);
+  padding: var(--spacing-2xl);
+  border-left: 3px solid var(--accent-color);
+  transition: background-color var(--transition-normal);
+}
+
+.preview-heading {
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.1em;
+  margin-bottom: var(--spacing-lg);
+}
+
+.preview-list {
+  list-style: none;
+  counter-reset: preview-counter;
+  padding: 0;
+  margin: 0 0 var(--spacing-lg) 0;
+}
+
+.preview-list li {
+  counter-increment: preview-counter;
+  padding: var(--spacing-sm) 0;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.preview-list li:last-child {
+  border-bottom: none;
+}
+
+.preview-list li::before {
+  content: counter(preview-counter) ".";
+  font-weight: var(--font-weight-bold);
+  color: var(--accent-color);
+  margin-right: var(--spacing-sm);
+}
+
+.preview-note {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+/* Form Section */
+
+.resource-form-section {
+  padding: var(--spacing-3xl) 0;
+}
+
+.resource-form-content {
+  max-width: 32rem;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.resource-form-title {
+  font-size: 0.875rem;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.1em;
+  margin-bottom: var(--spacing-md);
+}
+
+.resource-form-description {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-xl);
+}
+
+.resource-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.form-row {
+  display: flex;
+  gap: var(--spacing-md);
+}
+
+.resource-input {
+  flex: 1;
+  padding: var(--spacing-md);
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  border: 1px solid var(--border-color);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  transition: border-color var(--transition-fast), background-color var(--transition-normal), color var(--transition-normal);
+}
+
+html[data-theme="dark"] .resource-input {
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.resource-input::placeholder {
+  color: var(--text-light);
+}
+
+.resource-input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+}
+
+.resource-button {
+  padding: var(--spacing-md) var(--spacing-lg);
+  background-color: var(--accent-color);
+  color: white;
+  border: none;
+  font-family: var(--font-sans);
+  font-weight: var(--font-weight-semibold);
+  font-size: 0.875rem;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.resource-button:hover {
+  background-color: var(--accent-hover);
+}
+
+.resource-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.form-fine-print {
+  font-size: 0.75rem;
+  color: var(--text-light);
+}
+
+.form-success {
+  text-align: center;
+}
+
+/* Resource page responsive */
+
+@media (max-width: 768px) {
+  .resource-hero-grid {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-xl);
+  }
+
+  .resource-title {
+    font-size: 2rem;
+  }
+
+  .form-row {
+    flex-direction: column;
   }
 }

--- a/site/resources/agent-evaluation-framework.html
+++ b/site/resources/agent-evaluation-framework.html
@@ -1,0 +1,91 @@
+---
+title: "The Agent Evaluation Framework"
+layout: "layout.html"
+---
+
+<section class="resource-hero">
+  <div class="container">
+    <div class="resource-hero-grid">
+      <div class="resource-hero-content">
+        <span class="resource-label">FREE FRAMEWORK</span>
+        <h2 class="resource-title">The Agent Evaluation Framework</h2>
+        <p class="resource-subtitle">Where AI agents actually make sense (and where they don't)</p>
+        <p class="resource-description">
+          I use this framework with every client engagement. Before we write a single line of agent code, we score the candidate process across five dimensions. Takes 10 minutes. Saves months of wasted effort.
+        </p>
+      </div>
+      <div class="resource-hero-preview">
+        <div class="preview-card">
+          <h3 class="preview-heading">THE FIVE DIMENSIONS</h3>
+          <ol class="preview-list">
+            <li><strong>Trigger Clarity</strong> &mdash; Is it repeatable?</li>
+            <li><strong>Data Availability</strong> &mdash; Is the input structured?</li>
+            <li><strong>Output Predictability</strong> &mdash; Is the decision space bounded?</li>
+            <li><strong>Risk Tolerance</strong> &mdash; What's the cost of error?</li>
+            <li><strong>ROI Signal</strong> &mdash; What's the current time cost?</li>
+          </ol>
+          <p class="preview-note">Score each 1&ndash;5. Add them up. Know exactly where to start.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="resource-form-section">
+  <div class="container">
+    <div class="resource-form-content">
+      <h3 class="resource-form-title">GET THE FRAMEWORK</h3>
+      <p class="resource-form-description">
+        Enter your name and email and I'll send you the one-page framework &mdash; the same one I use with clients to evaluate AI agent opportunities.
+      </p>
+      <form id="lead-magnet-form" class="resource-form">
+        <input type="hidden" name="leadMagnet" value="agent-evaluation-framework" />
+        <div class="form-row">
+          <input type="text" id="name" name="name" placeholder="Your name" class="resource-input" required />
+          <input type="email" id="email" name="email" placeholder="your@email.com" class="resource-input" required />
+        </div>
+        <button type="submit" class="resource-button">SEND ME THE FRAMEWORK</button>
+        <p class="form-fine-print">No spam. Just the framework. Unsubscribe anytime.</p>
+      </form>
+      <div id="form-success" class="form-success" style="display: none;">
+        <h3 class="resource-form-title">CHECK YOUR INBOX</h3>
+        <p class="resource-form-description">
+          The framework is on its way. If you don't see it in a few minutes, check your spam folder.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  var FORM_ENDPOINT = 'https://elliotbetancourt-contact-form.elliot-ee6.workers.dev';
+  var form = document.getElementById('lead-magnet-form');
+  var success = document.getElementById('form-success');
+
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    var button = form.querySelector('button');
+    button.disabled = true;
+    button.textContent = 'SENDING...';
+
+    var name = document.getElementById('name').value;
+    var email = document.getElementById('email').value;
+    var leadMagnet = form.querySelector('input[name="leadMagnet"]').value;
+
+    fetch(FORM_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: name, email: email, leadMagnet: leadMagnet })
+    })
+    .then(function(res) {
+      if (!res.ok) throw new Error('Submission failed');
+      form.style.display = 'none';
+      success.style.display = 'block';
+    })
+    .catch(function() {
+      button.disabled = false;
+      button.textContent = 'SEND ME THE FRAMEWORK';
+      alert('Something went wrong. Please try again or email elliot@elliotbetancourt.com');
+    });
+  });
+</script>

--- a/site/resources/files/agent-evaluation-framework.pdf
+++ b/site/resources/files/agent-evaluation-framework.pdf
@@ -1,0 +1,92 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R /F5 6 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Symbol /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
+7 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/PageMode /UseNone /Pages 10 0 R /Type /Catalog
+>>
+endobj
+9 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260311190924+01'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260311190924+01'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+10 0 obj
+<<
+/Count 1 /Kids [ 7 0 R ] /Type /Pages
+>>
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3556
+>>
+stream
+Gb!#^>Beg[&q801R$V^?e7Jj?7!6hI4\hGfdnR;gXPLPMKd%[s2+a_lBLR:Aa6tqe.FGRL>E4$"k1#&L@PAYCjdQ8R%Im5]^I^``C-jT2$5+scAgDcEVoa:31O8]71M7[:]s15>T@NjBBnhB[1u]!:ZPWCa.)qr'a*#)2*TK0N"4;N[npU,C+17_N8ht;o""oEB1Z/a%%%pt7]OK59"G6je-4<B]F'37(EujF<X><l)gF=i:8l\sMdc>V@]\qa-kmNB9r7D=";tn=eqT"9mG8K]rjsb&&'A^TP^8<*gP#TW1QLnl&QRT&\Q[0h,PcF;brq(&GDT@MXL(QG[58j_;7:8QjjX,'Nk%EaC/O*"[%Z+;45+Y%S\NYH:&_(It)1kR9Uk43Fk=/45rC(s[`3U&1n3Z!mH)<F3Oub3/ePqu$\aG7WQ*A3dS6f!?Ttg(p?`UJMEdXdAr^S6YaQ[<0PGk4b[,7Mn4i)hLKU!edWs^G5#jM'3/m<)@c=7('N`[/)_9_j4\4dT))OG53+Q4l2[A7B1&m=fq<!n[hFtG/f$>]iG;:ALiGg*21FB6[9VAbM#;P'/:eBDeT,q>/i9sB=/M'3U:fk=MMF;\G\Vbj3reBX%2hH?\ZCLgIIGk9BJD9$g&gV?!]m6e3S\*/f#oNHQ.e$i<bE5rT22`A/\S*7f'f?A,'H"a&@)MOQH^C[[&]1P#6KcJ@dppdGM4/Vj2#EpX,cXfPKo,.A7[[R&qVG+m-/7kpCBeKG"Qh)B.>hkj,Q)ZMO]f/lMXL@M/Pm2f-K@en-4J9GTjZ^kPl=;'e#+G4JP$H!Aa_THY1*["jZT$.EgI8/>[>$J?<\ho4Z`F6C`%DC:HG34t!EfhTaatfn[XnK:,DNlQM?XmJpQZBW[Yr[ZLL;n+?rOFGMR]H]-<U]QC"`,0i;jp.\`MUgS^CUu[",R#;,Z1_<PZ%A2Kc]`_;;T5hekT([M)'hVm.9:CUBWS?la?/*G9X[c18UA+>cqr/fRNmXr>55.,C()dD`<IkU!'AbAf,E^#]SJQD<bJ>;CAIV"m9<Vhfb&V-;t9S]gm>l#8&cZTYG5)e0ib(h44/hMIE\VC:BZrej&6CF.<)9pT:%Ot'\Qe7MT+$R;4WRXMMNX-.I+g\ldU9U2^4I$+X9Gau_Q(-IGmG[I5br6f7:MI/FeI+N,cYq`naH5S)nVQ))o-a]FY<lW[Y/Z&L^"UNY;CfI/1bT:1N2?^FG3nAc0;O6L/8,g&bdtT"@3KZ>@R[u1=jGIQ7._l)ff\1UG'*d>M\3Bnd<7gmZE"PCD33Q>2I<8j7##A_Urmtg1+0ta#-7Y>snc3Ckj5V?7c`N0P:a9".=]MJJ1=O=p$?=#BqNiJfH4?L7WoHet`@A8X_rq5<<':GQc![AZOs.?JUg248X<>>Df1IZ<N5X"RU.*W?,/t.DeTg?*.g27S0s@Ra6Z5.A3H)#5f^Ma]iJ6:=fL>:0g;P`6kVAWK#(=N=R]>AWXc]4o"*lZ6n@t_e<PMd1H$-2C#cn@Prd`rhc%)Q]7@m)V%=paq!g&EB)Hk%'\!*C,[:hj*AjB96&!4E1&YanXfX_2FX0!EWEE6gW)NT["ZFMD;*FUN3q175P42!p]-94X(!>N5B$SSW.nK*_FdS$&tFF`Q;(]aC'r^t8!4E%QfDl.QHQ"8?GGYUNQ4BqN(pC6Th*07[#jFfh[U[?ci(_6('QtJaWH0-@lcc6+^a)EhHaCGoN4f8I3HpQl#Dh(:EE,`;uBkR)&*;X]V'$7>PgM\)\k6TPoI^\-h#H@Mh;KMS1]?e7.,DN=PonMi&Aj,IJ-k/+Ib&2S#4F.Fp%u?uLJ\<f3F,Tb3AbVT'_accNhQ3kfWt*8-+#p"^9RA98/^6XXpS'6Jd&b@\[<&D(5nj&s:R/M+>u4HE*,s?W#38IM+id^IC2KDn.Pn1V[.i/p@IGQT&>HHFd.!-Ir)3lW(OdFW2,K-'mg<`lj/,g=du<,rLi]^Y6#KWXY09kelV+HrLONjV$"'6qY>bZ[Y-P@1S.!1BJ.B]H4b`6W<d%q:>*$*JI>R=iV)5<N^*BuqE`4_JE2+qCca!n0q)"I2XV#nSc)3b3Prnp3ZJ#*'\"l\PJf)DX\>\j0h$GA$8hs'V#BfG;@f*'f9<0fQe8;$#BMK2H8JZ\od)#efE6u#:+pC.Lp]._&nN2M4<kBXL'E8%1!QR)FUtBW'fi[*c%GM\:qu!VChtFTdT54>*%gM^eg#r\&*ha2gO!6mMYp3L]ADg8(G<lTW@0gN(3b!c7*&kPh:3R;>K=Z"GGO2bH'bH!."M:@Yn1;tIGk,YUPk!Ok`>!OmrKBPp&\--V.DC9Bg@<Fprn(!3"0K'7KHL^p6o^qIlHN%qji1SW#;5SU*B5;CH8A4t/.8=e>7&=&<o+Fp5C8#ERYfu]Vp2U9@q^*\m_MR%EJ^6M=[';hMbY<E`h)[<qA8,&8&O!)a-[NGRk,"4Wp33R893a"REP'`,I2iI9lDsnq$4H0'uTqOc;&WESNM5=Ah"hJmW+TdJFeA(%6*plDT`3&j>&?d?F"JV[n.C_dk]*,-NS*ed#9!D.=UMM,pc:Gnd6FEY7rSKFhr^b@%aNgF.\[m6C4Qu]TD\,Xq:#]'t`K26%"1K[n70Amrsc,&]5_ZgTuko[p=G.A0*`ncIhm5Qq[8MO=<9th8?u6JPGXXIsAiZGsS@-Ai:cF<h,`EhRni.`n)A&hBmr'0G+5W40%/L"/EmK4q--K#Fe4[rO>te&(X)T7ut#[EAL1rs(loO"d@bEg&@4dATaFF]t'HZ)DDn?ch`Uc\<,O_l/'NB7%RlQb6K$WNP8f+)m\7[J6A29=cbWtr/O__S/.G#*-ff%!US+;cPH<4\9E!u\D(K3QgjS2^&t%U(X-uSQC_\GY;_<h)';JB+hGU5`!dou#Yt$nBo;FPXFs@XmO=3W^0n5k<:r'UH<2:Xi-K?R+N>:s(\<>M,1bnZLD9@p$r$)m2if"EeM.DWMUh?,OIB$pQ/t#V*S8d_Q%XG],`H5_57-r9^<kaa@8Yd77b?h6D''[%T*X18&`1Se*mRV)6/Bge,-nc*c+[RUQ7Qj@C_>ef;;P@UD2Wl#PA@6!L[G1c-%GqAMZ)T?iV"sus+]AgH/@BGfbDa/-&e]P):^L>"F0$&7]O_tH/H50A\t].mU$QOIJFt_QcCa6;/IpZct1,bQHBUoG=HgmcLU=Y9P]c]iXF7-/^:sa0Q<H#a]0:^_;E5X%UHFfV`K[XmPB2s&?QjI4_9o>WuJ$@L&&OJlQLpElo+FMWIa99BUgR&m4K4sD<tbZ-.D5D5EL&%7K9M:7%`iW%6U='mE"3'Vk<+=9D!>*4)K;9eXCEB<FBi=!LMufcs.I<RHD(gRhYNJ8_c>EEd,m<pJ>Fk/.DM[i/bE)Z'U9UM[1#XVJEEU2>4^NrEVeXZ#6ET7Yqr.CbWXP[p7869.JR_C6:)N8WBR;;5nYah=]]4%`9<63SpKkLE5YtZJ_D!e6=lJAis'skHIsR+P>]^f;ZI9Yq8Y<F8=UbGFU>XN@hTLp=_A:?^:0GhOWGfT)Bbq7Llg~>endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000061 00000 n 
+0000000132 00000 n 
+0000000239 00000 n 
+0000000351 00000 n 
+0000000466 00000 n 
+0000000543 00000 n 
+0000000662 00000 n 
+0000000857 00000 n 
+0000000926 00000 n 
+0000001206 00000 n 
+0000001266 00000 n 
+trailer
+<<
+/ID 
+[<e9b932b91b8168fd1b0a5f0cd35efb1e><e9b932b91b8168fd1b0a5f0cd35efb1e>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 9 0 R
+/Root 8 0 R
+/Size 12
+>>
+startxref
+4914
+%%EOF

--- a/site/resources/files/first-30-days-checklist.pdf
+++ b/site/resources/files/first-30-days-checklist.pdf
@@ -1,0 +1,105 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 6 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/BaseFont /Symbol /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+7 0 obj
+<<
+/Contents 12 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/PageMode /UseNone /Pages 10 0 R /Type /Catalog
+>>
+endobj
+9 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260311191014+01'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260311191014+01'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+10 0 obj
+<<
+/Count 2 /Kids [ 5 0 R 7 0 R ] /Type /Pages
+>>
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2510
+>>
+stream
+Gb!#\gN)&i&Ui84oLfhMOg)cX2nu::flC?fhJB&oWRAs$(m;3.An]CR>bpr\3Bam.U*t*7V+R`J1<9KNds\h)oP&t8^gH=*:CEnt)?"Lf;Adet6"(BO2#Bi4Ag^q]K'?eW:F"T.QHKs/[u[b-bR9RLYOVB1S;ooCU*q'P;d@Ab0^PAP8+#p(j#E5"?#Mtr\.8\9mWbgfXehd<R*^'`!t./\XX)`$dQ36joN'K8(!V3&fk]FX9Tq.MO!qf]pk\6L15a*M+X'R4Tm&:$SieAqr&L*c;i9'RUI@r0Z_.80ENIA?\mEL#SLa#L%o2'Y?p[/BN!D_[5&?n%5BtDm:(Eg5LVmLR)GrWfkJ#,\AK4uI-Zj+'da;n7(EOJ^J#1=!FD\CeE]iN@r_"O8c?[/Z856@!j0+8PGNO,M:Iik:$#j:#399b98%]3+4GjB&C>o,]ZiJ/5kio]@=k4kk;ClB&@Ae7BFI!nuBLO(Y/*b-hg/Rj1Y=WG@85O%V3>Y_fiNn`B^f>%BCo&A_TM9._\L]:G6Ui;mW][IV/5%ED(4shMUl2OSRM4.&EqFq*8n4t[eT-?grU!%?<>i(lTJ%hS#e"89/@AnZ[dD4(rD'@@,jmX[f8XLRVnZ6a/oY"!0dT?Op6FO`gOcQ<'R,^.%\&(UZ$@=C,RP_;LaVKQe,'g>3Gj1e`DfYhM3)(!jn/AacOD5gc[Ga]Tfr`td_mu:E9&Nji'[?0au+lkk\U^N\%NVRj83?d?ok^Y`\cMnV"[@>Ds1OhP6_f]bn2HPb/)Z[aeHm$NQU3!S._6sBrU5Mlf*iHP3&6tgEXcMa5O_V9R-&Vs8"QQK8)k/d;R9lPN$9mA&.+(ohk,@Oi&,uBnAP\kLJmh+2K[a`m+h/KVPCc_hbK<]j5J\54&lOr[9ZG-P/uU>Vhcu?bRK<<XiS$"b')D0O)[.b&(q:2&-=@]dQT@.[,Ib`2Ri1ID'SOo+a]`<M%/^BZ@H?[@#W5Bo0(fFeWuTmSjB8niEFnRgQE[nsl$@\JY"L=NHZI6tj3O^49go14H)Lo<r%lh2h/;r58"-iI@WV[*I_Z2mqhl\T'6g)SG`2"O+_Sh8FlR10'KCWQdlL?h<'KCCA$G4BC/DqQOX_hNECNL!YAG$o(d$*-t)Om))ZBYEcs\+Pi#NeO$+>!Sg.'[H;e^_;/\GSlRGjU5f;I9]?ikr.b\WX$uCfKM1jJZEuk7QkJ9h.[=;o"8I@K)-VU\f@k%^R4Y8UK]MT81#/2*/*&/5ZBZC=Q*+;nZ8;f-XjJ+"3bo'/\n[<`\jucqUr&J@;(RL?(PLm]Ppt<sEN1Q03%r3Rkp=dapfAQUO`AN;^W!KRaRb<2@?q$8cj)Ob46d"JBTR&#lk]?+UH3:p=9FdL4E?4LK2-)=K@KV\l!(YeitmC7HeG'lX(%)5K\TB3?Ds?8]7"f%fBYJOmnOVE/j#T/i51d@KlBmM<Litd6HPbn8'd_d04emcq?*T&In40.B..SH%UJ\[IHNiNUB:NL!/'V!RIA1j'5JRVCN;hDQL6a1KAlPSLV5><d;,o.Hm^c]\)V]giUHi',8$GV?hq-MAQ5=l4=>4345^l>^uWpI?hA6T<M?qdR62@9<lOtVYBEg@!tQTQO^:Q-90=9o8_f=fiL>]TdCZGWqMorq&57Q:iEf&r>j7G/j\fdb+7ENK27lhDI,i87oU,E58+CXjJpI=H$C\n3\gZ$m6=A^_=J:u6'&W%C17h.co1$:?#AR[>L`Ge_cl8SbPllf69GYu>V;1^+6SFK\2B4rNUlV;G\b(:AL-.Bd7;7+e",,[EjSW#S0Mj"!5htt"k:/sT(WMK*i<J4MJU)F&6`BKA@W&29,dM&t1`?6V<.$Mr?:pQo_.:]u(#0j79o!NKBBFPTaeY)OLCWs8bM;P$3@=>E"tR(agUm&^U*X3-pJO3uN:n1F4rjKS#@;;mgg']Ii*1N=&ph[BPf$T?PhMnLIuItrH7<NVP('Fi@C">.$p[Ko*pU__&l%rtKY<C!,u:"<::YYC%-KA\Q'EBEON92K;B9=Kl#W=J\6=>qZ0bKY[$Cc1?RuX77q!7Oj0tpjj]2i%o;XuU\s!0P^c.cY?4+E=TkUM9gl2R%"ZjU<<0YuGaZ?9<1O^ia.N\G9\:42D!N^eA!Wu0G6*aR]$k[3N'CeVC@f52g!F9u4,OPnY%rX*achs/ePEE*o6W\/Hi&It$_+Oh&X[t#rof0Q%S`01dke->H;!j5`.k.b+!<8c3\OSOmV34O%Ps'&?,NKtDnj@mW9o*@116^HAk0eTuc1VYJR!`7Rq-LTJ`aSAL)WMW:67-*;::oM@]#/24AN"1(f@$h_<u/de._:&EiJ3e$:gmAIX:p4m808Jgqp'lDB6E=BaI2@%rCZm38W<rS><e>*?H>1iq,[3)IWM<8ID]BmB:F+KU.LF,n!F)5.Quq9@._ZO\^Yb'"KeJM;;h01I6,,%G#7!F#2Pf3jMlr59"!]<dW2ThWBrbAlQJ6i@.>m4p3iWurrLqPVQK~>endstream
+endobj
+12 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2366
+>>
+stream
+Gb!#\>BAQ=%Y!$5^rnauk1C)\U85GH@]*p':#!&*9OI@r,!g9cE`^q"9$tlYnHW/oPc[S8\]bqP4X*<H(Vg:6"0`AjoG@>L]E,O1_ooM$6nunYLsdE"q)e@k55I5GB%&H%`NXhLpESd,cfh235<pW(N.NmTA`4>T1nB<[)$Ju]*^mZRQSDn\dm4$uNI#0!BH2\.#"]$j"tkA+CT/?0TG&g,X`<hRN[O>ILtkS(6k-Wshr3J^q@7DNZ>E>%*5I%)d(d+.?4:l1quH><@/baHr]t.5APU*M8fs6>*YT)qD5V7_a2p:fp#AV)No86U7_rUDCN"4p%A_I?/4cFg^CI`r-:tu.a&<q#E(#<p;RZA^gDHZDiJBokkMgEu#=r1;S[)#?,\pm12YMtVLXO5lSb16Sj$7tn1[k@^9E.SAqA%d('FqrZ#^V=s32u>^<#\mroM@ML9@?MCXqoU)7^p2Oooa-h*_-iG]RN)(:>!O`fC+\_,:Q<q?6oaPs56BSFbmI\*)0g5Ih][W0-4ss@_tmd-d"h[0P5a-R'5tk?;nQi&+%s%6d\R[>h%2&+J?MRY0^u-(BpfY430BAqMd,cY4Rf;'Fb`pXeOI/*E6L%[)(0u+`lKO8aRFM`SMu/@*sO+(]['%]`DtX+kPP`:S9RjD2[1<,Fh,26!D>YM'N7lauB2]4MZ,&ads*QGKLe/ZoLKPbPTGaOZs08>[!j/.#hnZXj+`qV#RU)?W`u7L78XgKBens$:]BQ6q-$uYXWY#k61Y/84j313.i'@>Z^Q>TnOp$Hg*#Z^o]IJoQKCk$3T<>[$L;SEr*;'ZKG?P*29$"T+U@<;4t<iOG^:fju$h='LE'I/h#jSq8jSh0_teb8*#FINhHEa]#pGpN-9eUr=Vf)(0VA^-10]#dn=0(;TQEqK,RIE\g0d!C@Z(uG+ca2V7,gWOZG"Ll].a=@^IClZh<O-UuUr)+jD`/-MLZuTJJ@4]nJsANQ0=9eN1&<ghq-V#q$\)UbH0,HIFQ/V883EVtq^g\f/4PDu?J@-'WM(TE#2e)R(RdM0*L3n19mim&LNB*ok"&VSC_?"k2Y65Fk:1X"P#U8G=kE*4J\STWHJt:L$iLF4,)&hVPrYI03-QoFMS&RPHt&lBkWRgbha"8Q!@S+J[2T(Vjf7>E3f1['D<OE<Z7P':8$70IQTU5[eDaet"7`Bf>iT5gNWCAPfg2ERnf/'1jXu0/e%W<nDcad8Y7W*MJ=Y3eUrE-";:a=9k;$eF1q#V=?D;DJ`GN$?#]rLB#'865@'_iI*<-)3^d?pjV&MYMoR#id8SY2cSF6_c8mNNWU3i^b2?j@7]"5Jn\AG*;u&Hl^>tki;_5K-0&.tCmagRc<JV=N7^Bup'>:Po&O;@4=kO-Q$nFm_HQ-@R/tM^l.[X?Och4t+B:1m]6%,RW-P.IG*Y1Q,^MXVp61#W=a3r&%@(a,1h(_5bMT\1<`C`NB(TS;6=DH';^duNgEDKoV/LlLY8)2R$m'<\"\X7UnRTNd@?E:b'j%DUJ<:t/6<^PVJi[@MX[X8)fB7,_PNRSa*=%l]2nh$(nS0Zj.(s5+%\(DM%T_^,fPWYO63<MnY&$a2>:SWjlg5>*Z^O44b"&@/.qWp!OQuqs)ha(UlsUVi5V\jhT+?fDF)/SLEQWPPH#*Q:juH@S9e@[9"qPt'M9*"5%:IbrSB&^$b-5nfQ?"$qH%/<bX0h=>jm#EE`.@@<&S@cqj-'\0RfrU6h0f@o\pPV<.#b%-/KbN&'g,fM'(#/?esW^YU>f_S?$hO@g%b84HRMLD9NudT#drW*l+S*>BbtZH(*)d"bPIO*O9Y;o4CC\?\lmUooA+*oa<P&(_D_6c>4Lob"dY#_LhDUJ9J_7U;^l>u\hb"g8n]jLmGHBVX#1?XPiUY.^VF\<07`pekDop_hng2&+d@?op:5XlGVYA?5B8C)F^S?3RAR3<,t(N,7+n\3)/[l^;O[VGI;?E`"d:@(EkM3[/Io(#'),a(K2Hh/-%9udT*,J81V=\R'Kpn@^<9(T?gCS()1Ms:YD%G7HkZXc$+D,U$U<`[X&8\GDJ7?MrRqa[3uH4i*3bL]qf@tM]ch%+oE`(*'@1O[QJ#m5Gg3-S1f2]',H1Tgg:*/X+.qT[l,*E)W;X7:-!J^jP[3R\k(=;;V"blT;'Auu%$_k@J"tcq$<GY"nNg/(5G:4d2u,qRZ9KPpSEiqe:.\'m;,T@-q4ir:]YM$TmOJ5N5=tV&Y_`%[daQL.;0t.QdSr!K<&+U>Ju\PdgK;NIU$hXcE]YK0=OmF<+\)p"$hu.:%<ZqfGkpRmWb]_4XDB2L9A3esVF$Rp)QK7\@n$[!RiK&,>,!c>:85eplGs8VN;a&e_FlK~>endstream
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000000061 00000 n 
+0000000122 00000 n 
+0000000229 00000 n 
+0000000341 00000 n 
+0000000456 00000 n 
+0000000651 00000 n 
+0000000728 00000 n 
+0000000923 00000 n 
+0000000992 00000 n 
+0000001272 00000 n 
+0000001338 00000 n 
+0000003940 00000 n 
+trailer
+<<
+/ID 
+[<e2df65de64124fe98b058b12c07d0e64><e2df65de64124fe98b058b12c07d0e64>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 9 0 R
+/Root 8 0 R
+/Size 13
+>>
+startxref
+6398
+%%EOF

--- a/site/resources/first-30-days-checklist.html
+++ b/site/resources/first-30-days-checklist.html
@@ -1,0 +1,90 @@
+---
+title: "The First 30 Days: A Fractional CTO's Field Checklist"
+layout: "layout.html"
+---
+
+<section class="resource-hero">
+  <div class="container">
+    <div class="resource-hero-grid">
+      <div class="resource-hero-content">
+        <span class="resource-label">FREE CHECKLIST</span>
+        <h2 class="resource-title">The First 30 Days</h2>
+        <p class="resource-subtitle">A Fractional CTO's field checklist for new engagements</p>
+        <p class="resource-description">
+          Every engagement starts the same way &mdash; you walk into a codebase, a team, and a set of problems no one fully agrees on. This is the checklist I run through in the first 30 days. What to diagnose, what to fix immediately, and what to leave alone.
+        </p>
+      </div>
+      <div class="resource-hero-preview">
+        <div class="preview-card">
+          <h3 class="preview-heading">THE FOUR WEEKS</h3>
+          <ol class="preview-list">
+            <li><strong>Week 1: Diagnose</strong> &mdash; Map the real system, not the documented one</li>
+            <li><strong>Week 2: Quick Wins</strong> &mdash; Build trust by fixing what the team feels</li>
+            <li><strong>Week 3: Install Systems</strong> &mdash; Create the rhythm that outlasts you</li>
+            <li><strong>Week 4: Baseline</strong> &mdash; Make progress measurable, start the handoff</li>
+          </ol>
+          <p class="preview-note">What to do &mdash; and just as important, what to leave alone.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="resource-form-section">
+  <div class="container">
+    <div class="resource-form-content">
+      <h3 class="resource-form-title">GET THE CHECKLIST</h3>
+      <p class="resource-form-description">
+        Enter your name and email and I'll send you the full checklist &mdash; the same one I use when I start a new fractional CTO engagement.
+      </p>
+      <form id="lead-magnet-form" class="resource-form">
+        <input type="hidden" name="leadMagnet" value="first-30-days-checklist" />
+        <div class="form-row">
+          <input type="text" id="name" name="name" placeholder="Your name" class="resource-input" required />
+          <input type="email" id="email" name="email" placeholder="your@email.com" class="resource-input" required />
+        </div>
+        <button type="submit" class="resource-button">SEND ME THE CHECKLIST</button>
+        <p class="form-fine-print">No spam. Just the checklist. Unsubscribe anytime.</p>
+      </form>
+      <div id="form-success" class="form-success" style="display: none;">
+        <h3 class="resource-form-title">CHECK YOUR INBOX</h3>
+        <p class="resource-form-description">
+          The checklist is on its way. If you don't see it in a few minutes, check your spam folder.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  var FORM_ENDPOINT = 'https://elliotbetancourt-contact-form.elliot-ee6.workers.dev';
+  var form = document.getElementById('lead-magnet-form');
+  var success = document.getElementById('form-success');
+
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    var button = form.querySelector('button');
+    button.disabled = true;
+    button.textContent = 'SENDING...';
+
+    var name = document.getElementById('name').value;
+    var email = document.getElementById('email').value;
+    var leadMagnet = form.querySelector('input[name="leadMagnet"]').value;
+
+    fetch(FORM_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: name, email: email, leadMagnet: leadMagnet })
+    })
+    .then(function(res) {
+      if (!res.ok) throw new Error('Submission failed');
+      form.style.display = 'none';
+      success.style.display = 'block';
+    })
+    .catch(function() {
+      button.disabled = false;
+      button.textContent = 'SEND ME THE CHECKLIST';
+      alert('Something went wrong. Please try again or email elliot@elliotbetancourt.com');
+    });
+  });
+</script>

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,0 +1,107 @@
+// Lead magnet lookup table
+// Add new entries here when creating new lead magnets.
+// fileUrl: public URL to the PDF (hosted on elliotbetancourt.com/resources/files/)
+// description: used in EmailOctopus email subject/body via {{ LeadMagnetDescription }}
+const LEAD_MAGNETS = {
+  'agent-evaluation-framework': {
+    fileUrl: 'https://elliotbetancourt.com/resources/files/agent-evaluation-framework.pdf',
+    description: 'Agent Evaluation Framework PDF',
+  },
+  'first-30-days-checklist': {
+    fileUrl: 'https://elliotbetancourt.com/resources/files/first-30-days-checklist.pdf',
+    description: 'First 30 Days AI Agent Checklist',
+  },
+};
+
+export default {
+  async fetch(request, env) {
+    const corsHeaders = {
+      'Access-Control-Allow-Origin': env.ALLOWED_ORIGIN,
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    };
+
+    // Handle preflight
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders });
+    }
+
+    if (request.method !== 'POST') {
+      return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+        status: 405,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    try {
+      const { name, email, message, leadMagnet } = await request.json();
+
+      if (!email || !name) {
+        return new Response(JSON.stringify({ error: 'Name and email are required' }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Build tags — always include brand tag
+      const tags = { [env.CONTACT_BRAND]: true };
+
+      // Build fields
+      const fields = {
+        FullName: name,
+        ContactMessage: message || '',
+        ContactBrand: env.CONTACT_BRAND,
+      };
+
+      if (leadMagnet) {
+        tags['lead-magnet'] = true;
+        tags[leadMagnet] = true;
+
+        // Look up file URL and description for EmailOctopus template variables
+        const magnet = LEAD_MAGNETS[leadMagnet];
+        if (magnet) {
+          fields.LeadMagnetUrl = magnet.fileUrl;
+          fields.LeadMagnetDescription = magnet.description;
+        }
+      } else {
+        tags['website-inquiry'] = true;
+      }
+
+      const res = await fetch(
+        `https://api.emailoctopus.com/lists/${env.EMAILOCTOPUS_LIST_ID}/contacts`,
+        {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${env.EMAILOCTOPUS_API_KEY}`,
+          },
+          body: JSON.stringify({
+            email_address: email,
+            fields,
+            tags,
+            status: 'subscribed',
+          }),
+        }
+      );
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        return new Response(JSON.stringify({ error: 'Submission failed', details: data }), {
+          status: res.status,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    } catch (err) {
+      return new Response(JSON.stringify({ error: 'Internal error' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+  },
+};

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,10 @@
+name = "elliotbetancourt-contact-form"
+main = "index.js"
+compatibility_date = "2024-01-01"
+
+[vars]
+EMAILOCTOPUS_LIST_ID = "5d9d842c-aa91-11ee-b601-2bca8e4b2516"
+CONTACT_BRAND = "elliotbetancourt"
+ALLOWED_ORIGIN = "https://elliotbetancourt.com"
+
+# API key is set as a secret: npx wrangler secret put EMAILOCTOPUS_API_KEY


### PR DESCRIPTION
## Summary

- Two lead magnet landing pages with email-gated download forms
  - `/resources/agent-evaluation-framework` — AI agent use case scoring framework
  - `/resources/first-30-days-checklist` — Fractional CTO's first 30 days field checklist
- PDFs hosted directly on the site at `/resources/files/`
- Cloudflare Worker (`worker/`) for EmailOctopus integration with lead magnet lookup table
- Resource page CSS (responsive, dark mode support) added to `swiss-design.css`

## How it works

1. LinkedIn post uses comment-trigger CTA ("Comment CHECKLIST")
2. Reply to commenters with landing page link
3. Visitor enters name + email on landing page
4. Form POSTs to Cloudflare Worker
5. Worker looks up the lead magnet slug → sets `LeadMagnetUrl` and `LeadMagnetDescription` fields on the EmailOctopus contact
6. Single EmailOctopus automation (trigger: `lead-magnet` tag) sends email using those variables

Adding future lead magnets = drop PDF in `site/resources/files/`, add 3 lines to worker lookup table, copy a landing page HTML.

## Deploy steps after merge

1. Site auto-deploys via GitHub Actions (landing pages + PDFs)
2. Worker needs manual deploy: `cd worker && npx wrangler deploy`
3. First time: `npx wrangler secret put EMAILOCTOPUS_API_KEY`
4. EmailOctopus: create `LeadMagnetUrl` + `LeadMagnetDescription` custom fields, one automation on `lead-magnet` tag

## Test plan

- [ ] Verify landing pages render at `/resources/agent-evaluation-framework` and `/resources/first-30-days-checklist`
- [ ] Verify PDFs download from `/resources/files/*.pdf`
- [ ] Dark mode toggle works on landing pages
- [ ] Mobile responsive layout
- [ ] Deploy worker and test form submission end-to-end
- [ ] Verify EmailOctopus receives contact with correct tags and fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)