### PR TITLE
Add Cloudflare Pages preview deployments

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,85 @@
+name: Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Allow one concurrent preview deploy per PR
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  deployments: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Deploy site to Cloudflare Pages
+        id: deploy-site
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy _site --project-name=elliotbetancourt-preview --branch=${{ github.head_ref }}
+
+      - name: Deploy worker preview
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --env preview
+          workingDirectory: worker
+        continue-on-error: true
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const safeBranch = branch.replace(/[^a-z0-9-]/gi, '-');
+            const previewUrl = `https://${safeBranch}.elliotbetancourt-preview.pages.dev`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Preview deployment')
+            );
+
+            const body = `🌐 **Preview deployment ready**\n\n` +
+              `**Site:** ${previewUrl}\n` +
+              `**Branch:** \`${branch}\`\n\n` +
+              `_Updated: ${new Date().toISOString()}_`;
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -8,3 +8,12 @@ CONTACT_BRAND = "elliotbetancourt"
 ALLOWED_ORIGIN = "https://elliotbetancourt.com"
 
 # API key is set as a secret: npx wrangler secret put EMAILOCTOPUS_API_KEY
+
+[env.preview]
+name = "elliotbetancourt-contact-form-preview"
+compatibility_date = "2024-01-01"
+
+[env.preview.vars]
+EMAILOCTOPUS_LIST_ID = "preview-disabled"
+CONTACT_BRAND = "elliotbetancourt-preview"
+ALLOWED_ORIGIN = "*"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/preview.yml` — auto-deploys PR branches to Cloudflare Pages
- Adds `[env.preview]` to `worker/wrangler.toml` — prevents form submissions from hitting production EmailOctopus
- Bot comments preview URL on each PR push
- Preview URLs: `<branch>.elliotbetancourt-preview.pages.dev`

## Test plan
- [ ] This PR itself should trigger the preview workflow (meta!)
- [ ] Verify preview URL is commented on this PR
- [ ] Verify form submission on preview doesn't create real contacts
- [ ] Verify production deploy (GitHub Pages) is unaffected
- [ ] After merge, create a test PR to verify workflow runs on future PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)