### PR TITLE
Lead magnet: AI Agent Systems Audit + Fri blog

### DIFF
--- a/site/blog/2026-04-24-post-subscription-agent-economy.md
+++ b/site/blog/2026-04-24-post-subscription-agent-economy.md
@@ -1,0 +1,113 @@
+---
+title: 'The Post-Subscription Agent Economy'
+date: '2026-04-24'
+tags: ['ai-in-practice', 'architecture', 'unit-economics']
+summary: 'Anthropic just pulled OpenClaw off Claude subscription pricing. OpenAI and Google will follow. Here''s what that means for builders — and the architecture patterns that survive the shift.'
+---
+
+The agent buffet closed last week.
+
+On April 4, Anthropic ended the ability to power third-party agent tools like OpenClaw with Claude Pro and Max subscriptions. You can still use Claude models with OpenClaw — but only through the API at pay-per-token rates. For heavy agentic users, that's about five times more expensive than what the flat-rate subscription was covering.
+
+Anthropic's reason isn't wrong. Third-party tools bypass the prompt-cache optimizations their own products use, which means they consume inference without the efficiencies that made the subscription price viable. That's the technical truth.
+
+It's also the cover story.
+
+The real story is simpler: the math on subsidized agentic inference never held. Subscription pricing was built for the median user running a chat session, not for someone spinning up 135,000 concurrent agents. OpenAI and Google will follow — not because they want to, but because the unit economics don't work for anyone. Anthropic just had nothing to lose by being first.
+
+For anyone building on agents right now, this is the most consequential structural shift of 2026. And most builders are still pricing their products like the subsidy never ended.
+
+## What Actually Changed
+
+It's easy to read this as "AI got more expensive." That's not what happened.
+
+AI costs are on a declining curve — inference prices have dropped every year since 2023. What changed is that **agentic patterns** — tools like OpenClaw that run many LLM calls in tight loops, consume large contexts repeatedly, and maintain long-running tasks — just lost the subsidy that masked their real cost.
+
+Two different problems. The first (inference getting cheaper) is a tailwind for everyone. The second (agentic patterns losing their subsidy) is a specific repricing event that hits a specific class of builder.
+
+If your product depends on:
+- A user's Claude Pro or Max subscription powering your tool
+- OpenAI Plus covering the cost of your agentic workflows
+- Any flat-rate consumer subscription being elastic enough to absorb heavy agent use
+
+…your unit economics just moved against you by up to 5x. And your users haven't felt it yet, which means they haven't complained yet, which means you haven't had to explain it yet.
+
+The clock is running.
+
+## Lock-In 2.0
+
+Every platform shift has a lock-in mechanism. In the 2010s it was AWS egress fees and proprietary services. In the 2020s, it's subscription pricing.
+
+Subscription pricing created an implicit lock-in that most builders didn't notice: migrating to a new vendor meant re-architecting your entire cost model. When a flat rate covers all your usage, you don't track marginal cost per request. When you switch to an API-priced vendor, every agent call has a dollar sign on it. The shock isn't that the price went up — it's that the price is now visible.
+
+Vendors liked this because it made you dependent without being obvious. They could reprice with a footnote, as Anthropic just did, and you couldn't quickly migrate because you hadn't been modeling your workload that way.
+
+This is why builders who priced against API rates from the start see nothing change. They were never subsidized; they were paying the real cost. The post-subscription era is only traumatic for the builders who built on rented pricing.
+
+## The 5x Inflection
+
+Industry analysts put the gap between heavy-agentic flat-rate pricing and equivalent API pricing at about 5x. That's not a precise number — it varies by use pattern. But it's the right order of magnitude to make plans around.
+
+Ask yourself: **if my workload ran at 5x inference cost tomorrow, does the unit economics still work?**
+
+If the answer is no, you don't have a business that survives a vendor pricing decision. You have a bet on a specific pricing model continuing.
+
+Three things typically fail the 5x test:
+
+1. **Consumer-tier products using agents behind the scenes.** Your users pay $10/month; you pay $50/month in inference. That's not a price war you win.
+2. **Agentic workflows running on defaults (always Opus, always max tokens).** You can get a 3x reduction just by right-sizing the model per task.
+3. **Continuous-loop agents without deterministic scaffolding.** The LLM is handling tasks that don't need an LLM.
+
+## How JARVIS Survives the Shift
+
+I run my consulting business on a stack called JARVIS — an orchestrator plus sub-agents (Pepper for finance, Wong for inbox triage, Shuri for task sync, and others). It runs on a $6/mo DigitalOcean droplet with agents running on a schedule, not interactively.
+
+I'm running the 5x thought experiment on my own stack this week. Here's what I see:
+
+**Model tiering is already aggressive.** Haiku handles 70% of the work (summaries, extraction, routine triage). Sonnet handles 25% (reasoning, decision-making with stakes). Opus handles 5% (weekly reviews, complex planning). At 5x API rates, Haiku-first is the difference between "fine" and "costs more than a mortgage."
+
+**Scripts do what scripts should do.** The rule is: *scripts fetch, LLMs reason, deterministic code handles the rest*. I don't use an LLM to parse JSON. I don't use an LLM to poll APIs. I don't use an LLM to write to a database. Every time I catch myself using an LLM for something a shell script could do, I rewrite it. That happens more often than I'd like to admit.
+
+**Three-tier context.** Raw data never touches the LLM. A Haiku pass produces structured summaries. A second pass produces session-ready briefings. The LLM sees ~800 tokens at session start, not megabytes of raw logs. Context engineering is the biggest token lever most builders aren't pulling.
+
+**Agents have memory.** Every evaluation workflow has a ledger — what was decided, when, and why. This stops agents from re-evaluating the same candidates (I covered this in detail in OpenClaw Log #8). Not incidentally, it also cuts token usage in half for any workflow that runs daily.
+
+**Vendor mix is under construction.** I still lean heavily on Anthropic. The Anthropic/OpenClaw repricing is a direct cost signal to diversify — not because Claude is bad (it isn't), but because any vendor with pricing power over my business will eventually exercise it. Haiku-equivalent tasks should route to whichever vendor is cheapest that day.
+
+I'll be honest: JARVIS is maybe a B+ on the 5x test. Not because the architecture is wrong, but because I've been tolerating LLM calls that deterministic code could replace. The subscription subsidy made that tolerable. In the post-subscription era, it's a line item.
+
+## Five Design Principles for the Post-Subscription Era
+
+Distilled from my own practice and from the teams that already figured this out:
+
+### 1. Price against API rates from day one
+
+Subscription-priced inference is a cost optimization, not an architectural assumption. If your workload only works at flat rates, your workload doesn't work.
+
+### 2. Aggressive model tiering
+
+Every task should be asked: *what's the smallest model that works here?* The biggest model is almost never the right model. Cost scales with intent, not defaults.
+
+### 3. Deterministic scaffolds around every agent
+
+LLMs reason. Scripts fetch. Code handles the rest. Every deterministic step in your pipeline is a step the vendor can't reprice.
+
+### 4. Memory as architecture
+
+Agents don't remember unless you implement memory. A persistent ledger of decisions eliminates duplicate work and doubles as an audit trail. Build this in; don't retrofit it.
+
+### 5. Multi-vendor design
+
+Route tasks to vendors, not models. Haiku-tier tasks can go to Anthropic or Google or whoever's cheapest today. Sonnet-tier is more vendor-specific but still shoppable. Opus-tier is usually worth the single-vendor commitment, but be explicit about why.
+
+## The Takeaway
+
+The post-subscription era isn't a setback for agentic AI. It's the end of a transitional phase. The builders who took the subsidy as an architectural assumption are the ones who'll struggle. The builders who priced against real costs from the start will barely notice.
+
+The model is commodity. Architecture is the moat.
+
+For a minute the subsidy was the product. Now it's the architecture.
+
+---
+
+_If your AI project isn't working and you want to check where it's actually stuck, I built a 5-dimension audit that takes about 5 minutes. [Download it here](/resources/ai-agent-systems-audit). Most projects fail at dimension 3._

--- a/site/resources/ai-agent-systems-audit.html
+++ b/site/resources/ai-agent-systems-audit.html
@@ -1,0 +1,87 @@
+---
+title: "AI Agent Systems Audit"
+layout: "layout.html"
+---
+
+<section class="resource-hero">
+  <div class="container">
+    <div class="resource-hero-grid">
+      <div class="resource-hero-content">
+        <span class="resource-label">FREE AUDIT</span>
+        <h2 class="resource-title">The AI Agent Systems Audit</h2>
+        <p class="resource-subtitle">5 dimensions. 5 minutes. Know exactly where your AI project is stuck.</p>
+        <p class="resource-description">The first instinct when an AI project stalls is to blame the model. Nine times out of ten, the model isn't the problem. This one-page audit walks through five architectural dimensions &mdash; the shifts that separate AI projects that ship from the ones that don't. Score each 5, 3, or 1. The total (out of 25) tells you where to invest next.</p>
+      </div>
+      <div class="resource-hero-preview">
+        <div class="preview-card">
+          <h3 class="preview-heading">5 DIMENSIONS</h3>
+          <ol class="preview-list">
+            <li><strong>Architecture Clarity</strong> &mdash; Can you draw your system on a napkin?</li>
+            <li><strong>Model Right-Sizing</strong> &mdash; Paying Opus for work Haiku could handle?</li>
+            <li><strong>Determinism Layer</strong> &mdash; Is the LLM doing shell-script work?</li>
+            <li><strong>Agent Specialization</strong> &mdash; One mega-agent or a team?</li>
+            <li><strong>Observability</strong> &mdash; Can you explain a decision from yesterday?</li>
+          </ol>
+          <p class="preview-note">Most AI projects fail at dimension 3. The LLM isn't the bottleneck &mdash; the scaffold around it is.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="resource-form-section">
+  <div class="container">
+    <div class="resource-form-content">
+      <h3 class="resource-form-title">GET THE AUDIT</h3>
+      <p class="resource-form-description">Enter your email and I'll send the AI Agent Systems Audit straight to your inbox.</p>
+      <form id="lead-magnet-form" class="resource-form">
+        <input type="hidden" name="leadMagnet" value="ai-agent-systems-audit" />
+        <div class="form-row">
+          <input type="text" id="name" name="name" placeholder="Your name" class="resource-input" required />
+          <input type="email" id="email" name="email" placeholder="your@email.com" class="resource-input" required />
+        </div>
+        <button type="submit" class="resource-button">SEND ME THE AUDIT</button>
+        <p class="form-fine-print">No spam. Just the audit. Unsubscribe anytime.</p>
+      </form>
+      <div id="form-success" class="form-success" style="display: none;">
+        <h3 class="resource-form-title">CHECK YOUR INBOX</h3>
+        <p class="resource-form-description">
+          The audit is on its way. Check spam if you don't see it in a few minutes.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  var FORM_ENDPOINT = 'https://elliotbetancourt-contact-form.elliot-ee6.workers.dev';
+  var form = document.getElementById('lead-magnet-form');
+  var success = document.getElementById('form-success');
+
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    var button = form.querySelector('button');
+    button.disabled = true;
+    button.textContent = 'SENDING...';
+
+    var name = document.getElementById('name').value;
+    var email = document.getElementById('email').value;
+    var leadMagnet = form.querySelector('input[name="leadMagnet"]').value;
+
+    fetch(FORM_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: name, email: email, leadMagnet: leadMagnet })
+    })
+    .then(function(res) {
+      if (!res.ok) throw new Error('Submission failed');
+      form.style.display = 'none';
+      success.style.display = 'block';
+    })
+    .catch(function() {
+      button.disabled = false;
+      button.textContent = 'SEND ME THE AUDIT';
+      alert('Something went wrong. Please try again or email elliot@elliotbetancourt.com');
+    });
+  });
+</script>

--- a/site/resources/files/ai-agent-systems-audit.pdf
+++ b/site/resources/files/ai-agent-systems-audit.pdf
@@ -1,0 +1,1484 @@
+%PDF-1.7
+%€€€€
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 1
+  /Kids [83 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /StructTreeRoot
+  /RoleMap <<
+    /Datetime /Span
+    /Terms /Part
+    /Title /P
+    /Strong /Span
+    /Em /Span
+  >>
+  /K [4 0 R]
+  /ParentTree <<
+    /Nums [0 3 0 R]
+  >>
+  /ParentTreeNextKey 1
+>>
+endobj
+
+3 0 obj
+[60 0 R 59 0 R 58 0 R 57 0 R 57 0 R 56 0 R 54 0 R 54 0 R 51 0 R 51 0 R 51 0 R 51 0 R 51 0 R 51 0 R 51 0 R 51 0 R 51 0 R 51 0 R 50 0 R 48 0 R 48 0 R 45 0 R 45 0 R 45 0 R 45 0 R 45 0 R 45 0 R 45 0 R 45 0 R 45 0 R 45 0 R 44 0 R 42 0 R 42 0 R 39 0 R 39 0 R 39 0 R 39 0 R 39 0 R 39 0 R 39 0 R 39 0 R 39 0 R 39 0 R 36 0 R 34 0 R 34 0 R 31 0 R 31 0 R 31 0 R 31 0 R 31 0 R 31 0 R 31 0 R 31 0 R 31 0 R 31 0 R 30 0 R 28 0 R 28 0 R 25 0 R 25 0 R 25 0 R 25 0 R 25 0 R 25 0 R 25 0 R 25 0 R 25 0 R 22 0 R 21 0 R 20 0 R 18 0 R 17 0 R 15 0 R 14 0 R 12 0 R 11 0 R 9 0 R 8 0 R 5 0 R 5 0 R]
+endobj
+
+4 0 obj
+<<
+  /Type /StructElem
+  /S /Document
+  /P 2 0 R
+  /K [60 0 R 59 0 R 58 0 R 57 0 R 23 0 R 22 0 R 6 0 R 5 0 R]
+>>
+endobj
+
+5 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 4 0 R
+  /K [80 81]
+  /Pg 83 0 R
+>>
+endobj
+
+6 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 4 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0.8980392 0.90588236 0.92156863]
+    /BorderThickness 0.5
+  >>]
+  /K [19 0 R 16 0 R 13 0 R 10 0 R 7 0 R]
+>>
+endobj
+
+7 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 6 0 R
+  /K [9 0 R 8 0 R]
+>>
+endobj
+
+8 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 7 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [79]
+  /Pg 83 0 R
+>>
+endobj
+
+9 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 7 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [78]
+  /Pg 83 0 R
+>>
+endobj
+
+10 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 6 0 R
+  /K [12 0 R 11 0 R]
+>>
+endobj
+
+11 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 10 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [77]
+  /Pg 83 0 R
+>>
+endobj
+
+12 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 10 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [76]
+  /Pg 83 0 R
+>>
+endobj
+
+13 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 6 0 R
+  /K [15 0 R 14 0 R]
+>>
+endobj
+
+14 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 13 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [75]
+  /Pg 83 0 R
+>>
+endobj
+
+15 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 13 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [74]
+  /Pg 83 0 R
+>>
+endobj
+
+16 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 6 0 R
+  /K [18 0 R 17 0 R]
+>>
+endobj
+
+17 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 16 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [73]
+  /Pg 83 0 R
+>>
+endobj
+
+18 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 16 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [72]
+  /Pg 83 0 R
+>>
+endobj
+
+19 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 6 0 R
+  /K [21 0 R 20 0 R]
+>>
+endobj
+
+20 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 19 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [71]
+  /Pg 83 0 R
+>>
+endobj
+
+21 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 19 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [70]
+  /Pg 83 0 R
+>>
+endobj
+
+22 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 4 0 R
+  /K [69]
+  /Pg 83 0 R
+>>
+endobj
+
+23 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 4 0 R
+  /K [38 0 R 37 0 R 24 0 R]
+>>
+endobj
+
+24 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 23 0 R
+  /K [32 0 R 31 0 R 26 0 R 25 0 R]
+>>
+endobj
+
+25 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 24 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [60 61 62 63 64 65 66 67 68]
+  /Pg 83 0 R
+>>
+endobj
+
+26 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 24 0 R
+  /K [29 0 R 27 0 R]
+>>
+endobj
+
+27 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 26 0 R
+  /K [28 0 R]
+>>
+endobj
+
+28 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 27 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [58 59]
+  /Pg 83 0 R
+>>
+endobj
+
+29 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 26 0 R
+  /K [30 0 R]
+>>
+endobj
+
+30 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 29 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [57]
+  /Pg 83 0 R
+>>
+endobj
+
+31 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 24 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [47 48 49 50 51 52 53 54 55 56]
+  /Pg 83 0 R
+>>
+endobj
+
+32 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 24 0 R
+  /K [35 0 R 33 0 R]
+>>
+endobj
+
+33 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 32 0 R
+  /K [34 0 R]
+>>
+endobj
+
+34 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 33 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [45 46]
+  /Pg 83 0 R
+>>
+endobj
+
+35 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 32 0 R
+  /K [36 0 R]
+>>
+endobj
+
+36 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 35 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [44]
+  /Pg 83 0 R
+>>
+endobj
+
+37 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 23 0 R
+  /K []
+>>
+endobj
+
+38 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 23 0 R
+  /K [52 0 R 51 0 R 46 0 R 45 0 R 40 0 R 39 0 R]
+>>
+endobj
+
+39 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 38 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [34 35 36 37 38 39 40 41 42 43]
+  /Pg 83 0 R
+>>
+endobj
+
+40 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 38 0 R
+  /K [43 0 R 41 0 R]
+>>
+endobj
+
+41 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 40 0 R
+  /K [42 0 R]
+>>
+endobj
+
+42 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 41 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [32 33]
+  /Pg 83 0 R
+>>
+endobj
+
+43 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 40 0 R
+  /K [44 0 R]
+>>
+endobj
+
+44 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 43 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [31]
+  /Pg 83 0 R
+>>
+endobj
+
+45 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 38 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [21 22 23 24 25 26 27 28 29 30]
+  /Pg 83 0 R
+>>
+endobj
+
+46 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 38 0 R
+  /K [49 0 R 47 0 R]
+>>
+endobj
+
+47 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 46 0 R
+  /K [48 0 R]
+>>
+endobj
+
+48 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 47 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [19 20]
+  /Pg 83 0 R
+>>
+endobj
+
+49 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 46 0 R
+  /K [50 0 R]
+>>
+endobj
+
+50 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 49 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [18]
+  /Pg 83 0 R
+>>
+endobj
+
+51 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 38 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [8 9 10 11 12 13 14 15 16 17]
+  /Pg 83 0 R
+>>
+endobj
+
+52 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 38 0 R
+  /K [55 0 R 53 0 R]
+>>
+endobj
+
+53 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 52 0 R
+  /K [54 0 R]
+>>
+endobj
+
+54 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 53 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [6 7]
+  /Pg 83 0 R
+>>
+endobj
+
+55 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 52 0 R
+  /K [56 0 R]
+>>
+endobj
+
+56 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 55 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [5]
+  /Pg 83 0 R
+>>
+endobj
+
+57 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 4 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [3 4]
+  /Pg 83 0 R
+>>
+endobj
+
+58 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 4 0 R
+  /K [2]
+  /Pg 83 0 R
+>>
+endobj
+
+59 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 4 0 R
+  /K [1]
+  /Pg 83 0 R
+>>
+endobj
+
+60 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 4 0 R
+  /K [0]
+  /Pg 83 0 R
+>>
+endobj
+
+61 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /WVCEJX+HelveticaNeue-Bold
+  /Encoding /Identity-H
+  /DescendantFonts [62 0 R]
+  /ToUnicode 65 0 R
+>>
+endobj
+
+62 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType2
+  /BaseFont /WVCEJX+HelveticaNeue-Bold
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 64 0 R
+  /DW 0
+  /CIDToGIDMap /Identity
+  /W [0 0 500 1 1 611 2 2 593 3 3 574 4 4 278 5 5 685 6 6 295 7 7 611 8 8 593 9 9 352 10 10 649 11 11 519 12 12 537 13 13 906 14 14 593 15 15 611 16 16 258 17 17 611 18 18 389 19 19 574 20 20 814 21 21 574 22 23 611 24 24 278 25 25 258 26 26 611 27 27 278 28 28 741 29 29 333 30 31 278 32 34 556 35 35 296 36 36 556 37 37 296 38 38 520 39 39 537 40 40 741 41 41 1000 42 42 574 43 43 556 44 44 907 45 45 722 46 46 407 47 47 519 48 48 667 49 49 778 50 51 741 52 52 593 53 53 556]
+>>
+endobj
+
+63 0 obj
+<<
+  /Length 13
+  /Filter /FlateDecode
+>>
+stream
+xœûÿş  è÷
+endstream
+endobj
+
+64 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /WVCEJX+HelveticaNeue-Bold
+  /Flags 131076
+  /FontBBox [-18 -195 870 731]
+  /ItalicAngle 0
+  /Ascent 975
+  /Descent -217
+  /CapHeight 714
+  /StemV 168.6
+  /CIDSet 63 0 R
+  /FontFile2 66 0 R
+>>
+endobj
+
+65 0 obj
+<<
+  /Length 1352
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+53 beginbfchar
+<0001> <0054>
+<0002> <0068>
+<0003> <0065>
+<0004> <0020>
+<0005> <0041>
+<0006> <0049>
+<0007> <0067>
+<0008> <006E>
+<0009> <0074>
+<000A> <0053>
+<000B> <0079>
+<000C> <0073>
+<000D> <006D>
+<000E> <0075>
+<000F> <0064>
+<0010> <0069>
+<0011> <00660069>
+<0012> <0072>
+<0013> <0063>
+<0014> <0077>
+<0015> <0061>
+<0016> <0070>
+<0017> <006F>
+<0018> <006A>
+<0019> <006C>
+<001A> <0062>
+<001B> <002E>
+<001C> <004E>
+<001D> <0066>
+<001E> <002C>
+<001F> <0027>
+<0020> <0035>
+<0021> <0033>
+<0022> <0031>
+<0023> <0028>
+<0024> <0032>
+<0025> <0029>
+<0026> <0076>
+<0027> <0078>
+<0028> <0043>
+<0029> <2014>
+<002A> <006B>
+<002B> <003F>
+<002C> <004D>
+<002D> <0052>
+<002E> <002D>
+<002F> <007A>
+<0030> <0050>
+<0031> <004F>
+<0032> <0048>
+<0033> <0044>
+<0034> <004C>
+<0035> <0034>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+66 0 obj
+<<
+  /Length 7116
+  /Filter /FlateDecode
+>>
+stream
+xœåz{p[×yçïœ‹ Ä Ä“xPàKÅ‡¨‡E½(R6%S")ÑzF/›n¼ñ8²ª¶cOeK©âÄIÔ¨ãÔò6v®0ŞØm:Š›™2l6Ø4ãØi¢n3iäìl,Ü9ç^@”ì6ÙYÿ·šïÇsÏ=÷œß÷ú}ß%€<	©}§Oú}ÖvÀ VMÛøÎ×_ğ> Šì?4;}í¯.¢üäÀÔÄäí¿ÂÈ805!>+¼
+D² >ùØÉUí@dÀİ7ñ¿^ø×: 9àÈá‰ÇÑ)14	€ïÈÄá©¿ù“ïL ÍoâÅcGOœT_—€äC æŸ:öÎ«ƒ×€äÿp»‡ñ4>?`Â†eDjÀ5u8‰ƒ8ƒy|— ˜—×COEèÌÛ ¡zxôUBæÇ$²ü´Ô÷5TCØ³;.Ä|¾ş™¾«äá¸“@¢ş¸!æ¸*4lùÎùÎMóøLL^U5ñëÖÑàÔ¹±¤ï*¶Îø®bû¨ÿjÏ˜³"NµÇ%¨Ø:*¾Î¹1ß€ïe…Gø
+çÆ’wâÄØßU!4<ºeôê“}Î«=}cN¿ß×õ­áÑ«oõ9ıccq	êÊN}¾ş'fê•=kbÔÑ¸„*y•m£WŸt^í;wNù†üWß:wÎy.8&ı2 Ïšú%Ò3ÌoõıN6ôıcNÿX_\BulÃ¶Ñş>§ßÏv¢ı¤è[iÍJHu1	5Rı'©á÷Ôø{AjúxHÍ1	&iíÇCü ­ô|ÂOÊ?ù1[îA¸î?FØºa[L‚•#lÿ„®ÿ}vü^7|<ÂÎ˜„†°«‚pó*V"üä}€â‡Ü½rP˜!wh4 ñ›ı³ßLÎ–~Nê,%éèƒw†è· =@Gè4³ ¡E‚`‚’,BP›$hL„ÅTÚbÎ˜39¿õ§—~pç[tàN‘œ9¶V Nº ¶aSÖ²™ŠĞ1}·HĞ™Øïè¢|­[”P—„$Ùû$h“E˜¡æ“Í¦"¬PÃl®-ÈoÍæ3­6+4Pk‚æü|¶=™7G‡
+‘íN.ÜÉãæşÕ=¥%ÒÚÜæm= 
+÷ò-ÚH-¨B «‹¨FIµIYD>8ø€ÏT„QÙÑTQ¶NL&	î¥Tš»…L«MãÏ³}¨µÎC3­ù¶ !òì?“g<Íü#9¥r­ŞÛÛ11jêÛÛ5úiÏšî–ÎÒnì«ş¸óÈH&:4ÙŞ9¹.<<^ßÒ¶×å úMº 5h‚UR‚˜”P,ŠF`*‚B„Š£ã$‹@2m~{†üvœîúóÒ¯¿¸ŠÔä¿Rú©#êÒäõ;ù_¤\Oı Şáë;Wê\‚¸ÄõÎô!#Ş‰AÊEh¹‹†©´ã{:’EÔ!ÊŸ®3Iè0Iğ-Jğ±í.­qB6ˆAD" b"¦!â4D<ç!â2D¼oC„~|ˆÿïA—5I0.ÊW›r­_”PŸ”åÈ¢„HEÄ‘ç[‰›ŠpBËe§‰!ÖTA¬Z8Íµ…"šÑ˜kò&	©¥Tº) ¹l7Í´z¨µÎ@íæ 5˜ +œ±ÚÔÁ@(ô™ÖnJÂş˜³Fïnñ.Ñ“xç,mØ”Éo[åvä··'wØ)iëµk?/´¬Ù{d•ùqW¬ÍåÎ5×7Ä
+>W&R?FŞí‡¢ƒã­¹=ƒÍáæ¾¶uŞHluÄ’ê¾ëSØ°éwûMÊ¿×—õøéO¹şq
+T¼sû~ZÇl@½|›l¥_‚Û˜“ĞŠ“P“õ¢,Û•8bO°˜ŠPAä²Ê$‹ò†™‚ÌlLì,Æä‚Ö 5cVpÏqÇÊ™3¹›ó##ñ¿5V«µéëPñ_ØSú»pª¡š
+G(­o$Øûò¯è§ètáËÌ„æäŞŠ“gá…@6¹FÄÅMdAÇ×8Q,È¢YÅ²C3ÈbYÌ!‹Èâ
+²¸†,®#ı¸„š¥"¢ ŠaE“¬KjLV/¡ˆ‚¢‰‚©ˆ&4p¹É”J·Õìœİ4—MĞpB([¡=Ã#ÛŸİ#0«ôê¤uÇÑ¡£B™ÁºµÛ’¦:oÈâN‡ìô…äğşU©‡7&›:7FÂ;›\Ñ”ÕÛŞÒğ¯½w»]ÛÓ›V•Ùfk°Ú=uUÚú¨¯{ç*GC~K[º?áÖÖÔÖ7ºÁ:ÑÛ
+²|{yeÔ
+7$˜’,J¬“L—nO¢%(… Åf­SkÔ¡°ÕC2­y’ûásŸ¢§MítY£u¶ÛĞÖÚ_ú"Ù[rÍö@Tôò\Eîå[äCjA‡ïêÌ7ÊÃ‚¯IÆ8RÁ8¢`Ìî¤%¤’òÌ†wNÁ;g*"¨àdæÉ,oI–Y<oSüùømöLB¸>)ƒÿÕ³´eíH<¶£·Ù•èğzÚã.“İ¥­Îªš»7G£Ã=avcãZ§ßh{,_ÏöGkÍÑşLcÚ_§ÑèŒõ“E+¸›S«C&cSOk éµhL>ŸÅaÔh­~~ôv@¦Äñm¨„6ô\6™Šp+‡b§KÏKÌ°ô0qlØh²	I	Î$ƒ®Š?1I¨2I°²ği’XdV!Â£cL‘”8¡ÅûD9h°ÉBGû¼Íë×‚F:¯±6y<ÁZÕ¼«u 9¿Ùnİ’ÎlvQMb¡¤£ÚŠÛK?&¾úd“½.h(İ »ZcuÙ@*‹ğ¸·|‹:)Ë›ŠĞ¢†oZkúh¬a°2“¼?î©âÜ…Å=3Ôü<~sĞ\Ç‚x	å°N÷¾Ò¿±°GKÚÜæ‰Ä×Â·|‹&è,ˆâ	-I‘åüÇ"pT	h-N	¶9jaƒ!h‘‡ĞbZLC‹ÓĞâhqZ\†¯C‹·¡-çA-Şƒ¶’Wæ½†E	Œ;Ù“EˆómˆÜ(ŒŠQÑ #ÜüÜD1ßJl±fÌAó}ù|MçJıI¯AïNƒ	·§õÛ…‘‚Û]mÏlq•¯3ér';=¾„Ëïx§—.”>…ãë'²ùÉMñ¦(ã
+í ş–sÚ>ª5•’!Ê™¢šiEVÙËypsÆü·óótÇ©SÃwnSœ°€6sÙ _ÉaØ‘í\n`ş ¼ù†…áe’à\”`g/ç&(s*mÅ©ê”ÅêÊNÅH*#G‹Ì %èXÎJ²¹ô‹ôIù¾}Qs-Jp.•yr0Ç²¬=ÇİÄM‚Ö&sÆÜE‚Öó{÷:ÜNGmÈ²sdùÂü<¹\ÚE.ïñúœÂ#DíìÙÃN<|ê”ÌÈg©V¤™9Ë[´Vò¾’gŠwø9ª`(ûp9¦åBLß<Óüù°Ş¥5œ­±€–{ç/‚ñMîæú‡y
+)¼9€OáRüĞeâVí‚.„àB.À…¸0NÃ…gàÂy¸p.¼Ş†«lÕ.¼è8Š°ÃÄ—´›˜Çú+ÕÏ^+üºlÂäü
+Ñµ;«÷öC}íûÏæ4mÂ©Ó¹ÉæÖ¡t}tÃşÎö‰ğ¡ı©‚'Ùîrw¤½2„aDN±™aËµHÏmà¹­ˆªŠdP¤TÚ/ç;ó2–Œ…>ı•g÷ĞÑs#tÏù¯>7J¢bé%²»ôe²çÎmò`ékJü¨§´ ÌÀZRé5R¨_# Á²Ğ25òè ·°rƒİ:›=˜ á
+ê°„íAcdœºi.%Äúv´„‡{£UÚ?V‰$ğPª©'åô¦W÷t§\Äèğ[¢)U±Úé˜M^»ÁPï3G6‘L·öFÌ5¾B²t+ØcÒ9ôAWm¨=+ÌZµÎn³;bct¦ªZ­­¹¡ÎÒ`T»Â¯òËh¯¢xSB,ÉÔkUÔ+;9Æê„%	Æ%Î»Œ¸	c™wá€Í0¢ #†`ÄŒ˜³0bF\€W`Ä5qFÎ»ì•:€{+ì<ÿ±Ñ(«˜wX“,¿É^ŞÄ«çŠªÀÉé{X‹&®ßû«bÎä2ŒÓÈ4AÎy¤#rëuîd0ô°ké‡ó´aKª°£àrµv¥†è¸+Şéõu&Üîd§×Ûw‘¯ßøM([ÿp¶mjc"í•k«[´‹cÆ“yMsRNÍr•Ì\‚{xb½K  F L8à ç\ğ:€·²×ï15Kh6Iğ,ñìÄ4 ÅMd¸´p@Ë(@‹!h1-f Å,´˜ƒ ÅhqZ\ç©
+¬fvTjæ Âğƒ,†¯ÀYm¸l£
+µı¦ÎjlL»u:wº±1åÖÍ‡övuí…öuuíêeè%:½Ş¤Ë•ìğvO†Bƒ“İİSƒáğà¯™¹¼ßãùÆr¾a›åƒ’k¬r®‘ ùh¾±
+VßB¾7¿£Î‘h6Ïûm–„î=¥²„Û#Ôsçn³\İÍu¿«nŸ_YO3³Záß‘ıE«øK4e?¬%€õ¸- Í 
+ † Œ˜0`À W \p¼*KSŒ2ÔÃªÔ?ÚŠ÷ÈrÅgê8³pV˜E“Â,šŸŸ1*>s?Çø8Ÿ1“W¸Ï›ğ„×÷JOŸ¥ö]…ğÆ®P¨kc85Ö@	õu&œÎD§Ï/_ÉŸİÉ÷¶4úz÷îïõ5EÏ èğ¸Ş`_."˜—§ÒmÖL®óÒÅ‹Ë=ú%º€l¸—?h”ªQ²–¥}9¿ÊVÅrTJÂ”&KJÎ'œY‘şç(i¾ô-ı€·¥~\
+Ğ…’Ÿü“¼oöcç0{îİ÷]¾¢äôÿ7nòïòûøÇG¸º–ÄpdäÔ'SùÕšEƒü»‰ÙyUò#xÛTcíºH×:¢­s}…¨ãâE“×Q+¬ÑB@ÖÅ™Ã_qÿ±ß×ƒ”û‚òFÒ…Ò›dŒ_íò¯i}Í8[„Wi/xMÜSt¸	]ÙStp@‡fèP€CĞa:Ì@‡Yè0.@‡+Ğát¸÷”f=f¥¼b“»q¢ˆF¥×hbõ”²õçüB¦›ÜvrŸÈv×øÃmäıÒlÿ“ÖTÈó™ÌŞ¸+Õ-Î“–uã™ÜîÁ¨»m8íuS<UzÂí¬kL9ÒMöBªmÛ*'iêÏ§wö„nú"ÇÀ¼|‹6Ğäˆ‘éÇX¡~¥ğuÈx¨qê2j~·jŞ‚cPcjÌB9¨qj\× Æu¨¡gE…nì>Eb}>Öí0r’)w;Z–XoEBZXiÜDºüŞ4H£iÆÒC3HciÌ!Hã
+Ò¸†4®#ÍõÀZ®mLw¶,%Väñ²Å±MVüĞÊµ æçnw%Îu“ræÑdB¼ÿUg ï6RŞŞ”7î1‘³¤©o¢#³{]Ko{:]»=š]¤gI[>ÜégÉ—'K4’é°5e\]»×<í#m#zjx “\×êöŒåóƒ©¸§ÑÂ"Äz€|¾-‚+›ÉÛ^pxujÂÖŒ™|îSêP[ÓUúF$ï×“ƒ%–d@]Ş@’ôŒ/B¯èY/óq=lĞ#=òĞc zŒ@ièqz<=ÎCËĞãuèñ6ôef Ç{Ğ3>^fÀ¬ÇÍø$k‚\6O’úÓ~sÿêÓ…L–ŞHüV~wÿáŸ=všq
+V’P;]@ÏÉ<ì®ÃÈ,Æ½Äª<nÕ¸‰ê²]TÃj4£TcÕC5fPYTcÕ¸€j\A5ØW£ë¨ævá®ğ"¹+Zg®-€‰–Jƒ4 €`™=#×?LÙŒ(ûsşn±lMŸ«ihñ&:Ü-Y{|KgÒÒk}ëWÂ½;S«'z|äW!é.d|­¿ÉÛ9¸«ëñÆ|2Õ±1—ÙºÊÓ²i?Ç`ùƒåxŸëf‚3rŸF-û 79ÄüÌz8 G3ô(@!è1=f Ç,ô˜ƒ Çèqz\çŠ’`^Z¡M¦[`d)µú´¿Õoê_}ª-›{-y|öVşÙşÃ?ìôO™nD€
+T„{òØİ§RÏXÈöW>˜ş“W©Xz‘LÜ¹-ç*ê "j†ôµJP•d›@ÃCCµ"¥Ò!ÓfÏmAM8X,¾xèĞKoşù¥]¾DL¥_}å+Äòë³gymù+ú&½0ë÷y”ÚÒ#Û²6x‚yx0 FàÁ4<8çáÁexğ:<x²-{ğ<rméPjK¯-ƒŠ:î¯+»é½…¥‡Rÿšü¶™­Ÿİ•JíúìÖŞ#[[Õ/ToY—[Ÿ°Zësî\ÔE~Ôığš@ûôÜğg'‘‡Ö®mîÛOö7[q†ûSø¾0MàßqÊ‘ŠÅ&î)ú.yàñÇA° ½œ‡dŠ¨Q|†uŒéâ}ºªúx¾‘S€6¯o›ù¾óõ¿dtã¿äş™~»H>Ãx¦ :zÂ@“5˜”‚²Î ÒXƒ¹n1œå}+Ù}éË$¸z¬mpO»ÃÑxUggc$`%ñˆ3ìĞ]¼x‘¬Ïïêm
+·¯u§ºc^oÄŠ·´7{<ÎDÌL:åxĞtFì¼—_Õ(á®Æ$sŠæ¹ÿ^^>ñİ³îåZ¬ö6gÌÌvûŸ£¯Ì¾BŸûÇ/Ò?ãŒë7¥òAIMJVò/Æù^¦¨Bß`õÕ½Ÿ÷XUXâß®˜ÇŠ¸É?Aqá€ˆfˆ(@ÄDŒAÄDÌBÄD\€ˆ+q"®óYòª5¬êe‰µ‡’Œ«8q†ìE–¤ì7åÜ…Ê°|ÆhrÖ^ê k‡±>‡°öt8!T2Ú;/çóù|é[—.ud«Ôjı¥š‘ZSrwæÜm›Räìõd6Ÿ"kïä‰=»ªewÀØ’J˜ù¸¿ŠÖ?´ºy0ÏZ# ÈáûdïÇÚmÄ»µäß¨ˆj„+s˜—‰w;8
+?e‡¯Zd|ĞŸó“œßš±‘¥Ÿ}ião<H’*ºùOt:81'ÁÍu#GP†"‹÷¶%	Y7Ü„¦¬Ö4h†h0Æ Á4˜…sĞà4¸®AƒëĞTtcd>fH²D*k@Ï5`ªpX†»Bçdä2÷ÎãÎÖİju–~qékkww8»×’ÇPeQ{¾“'÷lk‰mí	óúşWô]zãÿ»úş;,^–ã&»^buÛS,²>µEX²—…ÌæşÑd|G_3¡, &Ï>0<7İŞ>=w_½6¸2NŞkrrÜ,›œÂ±4+¾Wi!(åµ?ü,v˜ıæşKÄéRéŸxÜÈ–¾KJ¿$µå˜ñ_¹]:ğ„ü	e¥]:™ş>A»ä¾d¬D ‡ÒÆp°zÊ¼ÂıK<Ö¾9eõ´öJÿƒd·În‰¤w>Ú†üµ¿{g¾ckÆFîäÛ>óÀØ™Ñ˜‚c7]€ÈêeQÁQ”ù¨qåo³Îoî'¿-}•Ár†0<L uÑ7 ÀÀ*ç•J_¿F©bkÊ•¡¨ÄsU8•RBòæÿb*M¬Á6‹5“ËäXíl%«¤×„³ããŸ)-Rí­[¥^zéùZéÀSríL€?úu'Ùcìüq?gaëõµÿ{#»şôío<÷¡ºä/©Xß¼”ÊÏ·†[\úP]zT¼$3›ÿòä}˜é>èéäi7ÜÄĞo,@Âè§ûbãäa¨éìT³|›:àÎ¡Ïß¡h§û ò4>$$ ¦İğÑ}ü~ˆØ–©ÌÉ:é{è'› bC±a„ÆPKc0ÓÖ“²4+‰,@« R@ßCHø9¢İXKcğ	ˆ~ú÷è'Ï#G5°Ñ/ _Ğ"ÄÖåÿ· ŸÆ˜Î`C'Îá'ø	1‘ùm¥O	!á!áÕ^ÕËb¯xL¼©©ŸUWÓ©ùQÕãURÕ÷«OW?[ı÷ÚFí¨ö¸öıš·k~©k×½¡¯ÒGôÛõ£ÿ¡ÊĞkøÏFŸ±Õ¸Ë¸`zÄtÙl0'ÌÇ”şFçQÃP)ğ0óQE8_jñc&©Ø]ÆB™¬…šÙˆJŠ*î¯DU¨Q«ÈUª<—k@aSusYÇÇ·sÙŠZÕC\6óñ#\®eë«NsÙÂåOs¹ËOqÙ
+ƒês\fŞ§Sç²ûîœ*¾gÕKLÖ±Fc•ê2—µüÙ¿øôó¿La’ÿ<‰“X‹£8†YÇöã NÂ‡ö¡>^¯B±ŠÜºBÎ¬ğaG0©Œ”»1ƒ#8Š“˜Å1L)#{q8Yø0ˆÃØ‹uğá(Ã‡œÄ	¾Ú4¦1ƒC˜ÁNò=t½8Öa
+‡p>ìÃQÆ1¾Láğar÷îùØêÇùı)Çi¾rZh±ø'ù\¶“	ş4Ûçğ7L*;9Œ	ìÃ¾Ÿ)eÅ	Lb{qˆœÀQLã$åge#ÓÊá8_éöñç÷Ã‡“Ê»·+'›æë³]ú8L>Â÷ÌŞ~GáÃ,âÇŒÍb¸<ºb%ù-l­ã/†ğ4|±~CØËïîç?}èÃq¾§ƒüt'VœïGrp…–ËzZ¹7vº\ïåYlöfYg>ş>«•°3±§N)ç‹):8c8ÄW(æÏÌpË¸wæ>ÂÑ
+>2Î'¹±MóWî>Êw€£wrbSxŒï‹¡ÎÎö(·æ%28¦ìû4·ŒOQÙò~·®ªx[©r†¯3‰£
+¶Û0‹|Ç‡ù†»=cügÙ—VúÆÖ{|cëG|£Gq“Æ).É^y ‡A¾ê‰Ê•=Ë0;šZJ}˜ú—Ôõ7>üæÒw¿‰>.Ç0…ı
+ºGU6Õ*UªKµAUøôó›·©ê´z½:Ï¬	ş]‚ÿ[şS´Ş—•,	 °ÃzlÁNäñF0ŒQb#ŞÂ`ú°[±	›Ñ3oû¡E=l¨C¬¼û BøK<€ RÈÁ„qdĞŠ„‘„ì3DaÌÄ[yf„áEjYqWË›¨EŒÿ9Õİï™ƒ7a@
+MğÁ^™dD-÷Œ˜½g!°†»
+NVÈó+AËFYĞ×±]	²ğmˆğ?!­Ej[¾á†fhQÛ‚oƒ ƒ(ü°ÃÀ'PD€“ÿe\-[S„
+fFûÊoBş³‹´
+endstream
+endobj
+
+67 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /ZBEXFU+HelveticaNeue
+  /Encoding /Identity-H
+  /DescendantFonts [68 0 R]
+  /ToUnicode 71 0 R
+>>
+endobj
+
+68 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType2
+  /BaseFont /ZBEXFU+HelveticaNeue
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 70 0 R
+  /DW 0
+  /CIDToGIDMap /Identity
+  /W [0 0 500 1 1 556 2 2 278 3 3 704 4 4 222 5 5 853 6 6 537 7 7 556 8 8 500 9 9 574 10 10 315 11 11 537 12 12 574 13 13 926 14 14 556 15 15 500 16 16 648 17 17 556 18 18 333 19 19 648 20 20 259 21 21 648 22 22 222 23 23 537 24 24 278 25 25 519 26 26 611 27 27 222 28 28 685 29 29 600 30 30 593 31 31 278 32 32 593 33 33 518 34 34 296 35 35 278 36 36 500 37 37 518 38 38 593 39 39 556 40 40 871 41 41 758 42 42 577 43 43 480 44 44 389 45 46 556 47 47 500 48 48 648 49 49 278 50 50 1000 51 51 556 52 52 574 53 53 556 54 54 685 55 55 574 56 56 722 57 57 760 58 58 630 59 59 222]
+>>
+endobj
+
+69 0 obj
+<<
+  /Length 13
+  /Filter /FlateDecode
+>>
+stream
+xœûÿ>  #Õê
+endstream
+endobj
+
+70 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /ZBEXFU+HelveticaNeue
+  /Flags 131076
+  /FontBBox [-13 -213 914 786]
+  /ItalicAngle 0
+  /Ascent 952
+  /Descent -213
+  /CapHeight 714
+  /StemV 95.4
+  /CIDSet 69 0 R
+  /FontFile2 72 0 R
+>>
+endobj
+
+71 0 obj
+<<
+  /Length 1440
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+59 beginbfchar
+<0001> <0035>
+<0002> <0020>
+<0003> <0044>
+<0004> <0069>
+<0005> <006D>
+<0006> <0065>
+<0007> <006E>
+<0008> <0073>
+<0009> <006F>
+<000A> <0074>
+<000B> <0061>
+<000C> <0067>
+<000D> <0057>
+<000E> <0068>
+<000F> <0079>
+<0010> <0059>
+<0011> <0075>
+<0012> <0072>
+<0013> <0041>
+<0014> <0049>
+<0015> <0050>
+<0016> <006A>
+<0017> <0063>
+<0018> <0027>
+<0019> <006B>
+<001A> <0045>
+<001B> <006C>
+<001C> <0042>
+<001D> <003D>
+<001E> <0064>
+<001F> <002C>
+<0020> <0070>
+<0021> <0078>
+<0022> <0066>
+<0023> <003B>
+<0024> <0076>
+<0025> <00660069>
+<0026> <0062>
+<0027> <004C>
+<0028> <004D>
+<0029> <0077>
+<002A> <00660066>
+<002B> <007A>
+<002C> <002D>
+<002D> <0032>
+<002E> <0031>
+<002F> <2013>
+<0030> <0053>
+<0031> <002E>
+<0032> <2014>
+<0033> <0030>
+<0034> <0054>
+<0035> <0034>
+<0036> <0052>
+<0037> <0046>
+<0038> <0043>
+<0039> <004F>
+<003A> <0026>
+<003B> <007C>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+72 0 obj
+<<
+  /Length 7764
+  /Filter /FlateDecode
+>>
+stream
+xœå{{p[×yçï¼H qñ$x	€ A<Ä·DB¤hÉ%J¤,Š–DRd"‰ZI–­ÔÉªŞZ¶”¤µ³Z9mêM%Jã¬’´ö%ã4$v"6™åz³N“pÒl];©Öãq)mmÜ9ç^€ ¬I3;şcgVò~8÷<~ßã|ßï\ 0à<TH9{ÆW³Ÿğ<€š™“G¯¾}ãK ~¨›;7óÎ»wõ»@øog§MÚ‡ Ä~ 3;;}H÷ªö
+7hœ=~æ¡oÓÿ3O xëØü‘CÛ§gHø |èø¡‡NÒjÂ@âO øN:>ıOûQ;xĞ|ìäüé3Wİ£2 >sòÔôÉËÕ¾yÀ`ÃöÖ6Ã@50Ò%’P9<öB~\"kJ}¨[@%T“[$¨Ï×?×wÜß"F%ˆ¿E‚*êË_Wò#câ¸ï’ïÒàÔ%_Ş7{hêº:À¯#câô¥ñ¸ï:vÍù®cÏ˜ÿzÏ¸»$Non‘ fı¨y?—Æ}yß”>À{¸4_m‘ ‰ù®«‚Ãc»Æ®Ÿïs_ïéwûı¾şë/]¡Ïío‘ -ÍÔçëÿğ\2g]T‚6Ò"¡Bîe÷Øõóîë=ã—.)ŸhĞı…K—Ü—Äq¹EôKJƒşU _"=ÃüVèw³Ñ/úÇİşñ¾	•Ñ¡İcı}n¿ŸÍDÿHÑW©¡RcT‚CZõ>Ajúm ­ş­ 5ßR!*ÁÌ µÜRñ7 Zjè¹Âçe„Ïßaë„m¿a{9Â¨;GØù>!\óÛ ìú­®½;Âî¨„Z†°§„pû:Ê> xß!¯+ƒ)ò}ú=¨ Ã´[³„Š¸Ä%T˜%h—%hã Pİ’ óÔ\ª\Ò?&Aw³F}×¸Ò a¨YƒÚ¼ €Ş’ 1³Nè­D’ø¿UğäJá$•*¥O­~’^YÍÑï‚@\»MVéšñŒ„–ø"pBÕ,Áa–@—å«z™+¡Å,Á¿"Á¸Ò«ÁO`ÄMA'zİ¨„.†91#ÆaÄŒ8#.Âˆ+0âŒX€7`DÕÄ""pÂ/XrX„ X0/‚íL&æE¡ãrĞÌ¾®CP°äI’ö«œ]$Õê¥v›‰Š1½ªTkMoŠQ±A«µ‘W
+ŸÙ2èê4¶Gœ5á6¯/rÒQÒØµ+Ö5ÑUßØµ'Ş8è¤Azb¨ğ„Ú¨in#İ»UŒ»÷¤Ü¡-£-÷uz]µôû`Èb'@Ÿ¢K0Á…KpÇÙd«•ÉJp›%8V$èd„t¸	]!\Ğ!rĞa:ŒC‡9èp:\„W Ã5è° n@‡ª	,0óîa^D5—«Í‰d› ,^-ªyİAñ™§·ìÏ¹Ü‘t&a^½=şÈ¦¯~n˜FÛ¦{¶Lt5Z5ôC«™ÖÉîÿÒäõô`ëaöÈ×BKk¡Šæ™¬]³´rÍ$’Ö´XG„”ğÔè(=<;;±úÕ =€ÊNDğÜ"TÊ*³„ª•^&Q2Ñ«Â_Q¸Î	æ	5ì»€ùÎdQğ…ë\à^Y„ˆ*˜KN¥iYBS|a62oeZ‰rŠK0Å%¸âÌ®*»’]Ïº,Ë¾åDÒ*¤„M]”ÌÄLI’M+FÄ˜î­ö§uGåè@w}ÈQ1êjé¥FkÍ;Ç7SªY}‡l©n‰x…úˆ«ğÙÒ1`©Ô!¿Ó”kb‘DÓØ=²×nS G÷-Â†z>9›yvA»™}–@–™1H0.K0ÆÁ¬¢Q±ŠEÔBËåZîE¶’2Ù+,t©Øbœ¢‰0§iógØ’LÔÎœ'C>_øuÓ~æ){öú3‘®&!ÿ‰ÚÛîëO÷6Òú®ûºÆÎMŞt“ÓÊ|9Õê‰w6ÄgÇrM‡ÛÛ§šÆd oPNô—ÛÀ"L0pÙd–µe_–`çqGÖ–¢%c|VECVs™F%5pXƒ¹P2;*DúR§Ó2âb{´&›(|†ì‰ô·z0›¬_»M^¡6ã/˜K17Z„OAÙg^DõğqkIÆ¹ï&qÉ¢ï&áBa$‘CƒHbIÌ!‰sHâ"’¸‚$®!‰$qITMH0¬ÈšŠ¬H°¯H0˜%t¬`EKó"¨år€¹™YVd¹~%‘l+i¡˜*­Ø¤3SqÙ¼êbô;3J;v6‡îíÕÅ;}ŞD½Í²ÚÃ:ªjÈm6ô·‰­CcC­5¨­6ªùlbkØRìŠZı6®ÊZç°¹ªµ•6¿+Ş¨Äl¨5[/Øü5õf­ŞRì´–
+°"„¿a~&!—ĞÄlsY‚íe+½nh®Ò ËÓäì0à,€ .¸
+àY /¨šèÕàx¹Ä„„°Y‚wE‚^¦zÜ„¾¨=\Ğ#=rĞczŒC9èqz\„W Ç5è± =n@/GÓj¸J¾"BÃe‘ÙWÑİ‹›‰ÍK×7ıˆ+Úî÷·G]Åë~_ÏÁÎ®‰Ÿ¯g¢«ó`Ğø`kmmë`<>˜¬­MÆs‡ÃáÁÃ¹Ü‘ÁHdğ7»J€ÔÑ§ád^~g´e»?ó	İ²üÙ¹"¡J‰À6Iœ­ÀXZZYšÙÍ2Ûõ™CñÈlí)Áæ¥í$ÍÖ“RégGÇÆLuqoÈæ2iRÍ§>5Tx®1ZS9¤Ò[ªIïĞz,ÒS	l!Xòud¡Bjš¿Tp¢¦Y‚Ó,AÃ÷
+Ğ"²"‹²È#‹½ÈbYœEL·"‹O"Ëu›5/ÀÕ­æƒ·XoH(’„ä2óC	³„¾Rî`©N ¥Ü‡²*ç>¼¡‚5T°†Eh@à0/Àz«Wƒ‹ğà
+û0Ñ+ ÔÀƒ&x…ğ`ÌÂƒ‡àAÅDÑ™>c}Ğ!'b!†6Ä°1ìCGÃƒˆÉk½€.³'&‘PfÂ¢LqNË‰d@+6Ór f¾İÖ¥*&/¢¦í‚Í‘jm™4ö¢AR½#ä‰±;æö&»ıbwÂc÷‡m™‹;¢b¶Ag3T_2oÊmÕ	îF[¤#h¡UH$`nhE³¢E«ÓU¹j<m8—Ø¶èë³-…_{=šïºJ[Àg¯³T8Å°¥hqR šĞo,"¦aÌü^+Î.KÈÆ™qRdùZY«}™G…ˆ!ˆ2ˆ!ö"†Äp±hWÃ³ˆá%ÄŠQ!†×4ı0"ÆûõÇ%øVä‘»X\u#È§â6/B‡—uf–
+\›É€ ÚE¶óøIS­™¶ÔÆ2RôQ¤0Lœ#É­²5u›÷nnwP!¸9b…Üd”6u5>|æÍH¶Á$6‡›²¢Yhl’oonNİ{(–ÜiI44¤ê*m>gds£ù#,æòb oS½/½¥¡q '²Ø`TŸ K¨FZÙ5q	•Jy`à„REI2)R"é·Š*åÇš²¦¬ô|sòIúé£OÓzîÈçègéÒê—éÿÍĞ±Õ/”öé%ÔbKPJÊ÷éZ¥`×še	5qÈszïN½Ëù|î²g›¨N6ìÚÎdK£Ò¥ÕÌ·Şî¯!*Ö’äªX4*FùºPì¬Á^Ö ”FZ*¡ Xr¬úP¼Ø'ŒÁˆ6±FìƒGaÄƒ0½ØˆË¼Èa9™ÜC"©1©Ä†`(í%©ÖL7Q1°SÄP]'6{ª½&C¾V¬pÿÑ'÷÷7ù«ÕšË¹ÒÂ8ù<Ó5èº„
+4³|„¥,OÒrè A§ «³f¢áJ"ˆH„y€Çşû+ÿØ&I#¹ZøÙSØ_Xa¾JĞ³v›ãUÃtjDWñ.ê`õ]|NP>€ÜZÒpQ»°òÇ*Ì‰¤_î,Á4“ŠşCŞ(×in›RMaEÖ'9XøR¤¿Õİ’‘ç×	Ô
+Blqd½>X–P%Ì&ÛT¥œıqLµ:1İ9j‹¤ú÷×ó|ïõÖÏ~ÚÑ} koô	^Ï€\¶Ê^Ä`Ö•*)ÊJf©›¤¬*’jó;SäÆ9úà_n&±s…$!²£ğ5òÙÕÌ~D—øÜÙ¾Âûw–çµ
+ZˆËV?2Éš?¢ÔŒ‡¹®­¸(g»,(j‚åõ¬âÑÈY7ÙÖ%g9¸ Aä Á 4‡sĞàØf¦Áhp0C¿Ï;Y¯–/è92À•f†€¶!cÚê°Û´!VÂ¥^>.îÚUøÅäOÍÏ#gˆvkOO!{™w’“SSóã_­µ+5£m,(™6$!ìJWxÍ¸½yõªz9C±2Ò6“†`ÈîHµfµy,jÆæÌme%åêÍ¯~¯©Au7Ç¿qí6y›
+qn%FyÌ|oñÀ‚ğ òğ`/<˜gáÁxp\…ÏÂƒ—à)î-¼ÆS0W«m§yZø¹\ÌÊÍ,c5ÔzúÍÍ_)¥äÃAşlLlßí<Ğé­ï¼¯ıÈiÓ¾ŠmİM›s +–é!“±­Q{óĞôæÍ‡òÁÙû;¶øÒ}¡ÁlK”A0G¾‡gş]›ë£K…¡ò3ı ÕÑ%Z„Ay†ÕTÎe/`%~…Ÿ™nÊ"uºÍšRµ‰:¡tø+ÇV~pêfÂßÙ^øg2øüß“Ïƒp;î*Q©ŒQÉY03‹*(¦Í¼¬BÉOYä°
+ştñg'y«0ON>N~Ÿ2ü/Ã¯—Ö¡ØÖoZ{ÿèº©ø¼ÎÓ%èáG”fh†}Ä8&»Ìï#Ã’	\<Z†åJ1Œ›ûÃ…0ÿÉ!ŒA„10æÆ9„qa\A×ÆÂ¸0÷XË
+«€°ğ~™ÿ6,K°˜%ÄX^Ó ømƒ™)Wög÷g±„µbQ›i9qÑŠDğËÄP(İEØ%¦U¥»Ïüu}[¤fÛ®Â«d<½«Í“ß’jKŠæ–MiçŸÿØ›m®İÖMşèU]M4˜Ë‘ÔjFÌmm9`¢¶İ¹Ìv»^¯!«şÅà‰}<Î%p–6‘ßãû•“3W²Eh‰ÙÌª“D²Íîï¤~{‚ük¡b±¯ïB_ßzÍa¢K°"Š¯ËL¤ïÑ¢ Òğ¾Ö—ŒÛÔ/³0)ËòÎ'Ë‘e	‘ø"šÑ ;×
+k2ob¼¡RV§Xy[ßu¤Fqc¸HÙ?bnìhv…,B°£9Ü²’'F©)‹ÙÚÇÛë¼íã™ıvZdü™mÁÆ|[ƒ/ÓÿºTøµ³ŞZÑ<x¸­íğöh°™­š`÷Ú	|ó0¢…í÷²ÏYĞRjIw{À(ç2áÌt‘r˜¨ÎŞE:Éîv¢19…Í›æç·SÛ*Œä¦A±u­¶P5ˆ2†8_D2B’Ö”1Ä1³cïJÙ…œAºä½Í…›p=ÅÅ˜¿äàÂ \‡spá\¸®À…kpa.Ü€‹{
+ëY\– ó+šJ¹§W‰=^…1Jmd„Å´FQK1»ßÊq[Ëq'íæÆöh¹z¨f5CôÎzKE„C?5çïTJõı*ÕÀ€’Åé7dr:{+)‘´ªRmNzCâß|ëèOÿŞWg~÷áãÄ\xë•WˆóÍ¿ú+¹6 aú2œ¸w#§Ê8¦ç*…k*ñŒK,òéå"û’Š‘n¼|WpJ‹iFr:œiViëˆh?2:5ÕPo¨5ëùÁ}d±'‹C5*õvµº·{Çó[f{ß¦¨`fLßİøcv5,ËŒ±”i²oT³¹²óÎÌ@(Yf(ı­yÅ4Ó„\Ÿ/ü¸Ü@9æ&€¼N5<œoÜëÔwÖFVşÆøÇé““/PMaù¯«ï@Å±ı}™Ç­z|’…ØŠRˆ]Ÿš]‘gÌÛ_MË2}Ìø=võ(÷ı+JÄ2O,Ê&ÄêRu©.­SªS\©BŠ}®ZfzS+VâO	b:•f¹ÿ]µE~½QiT31[xë½Šc~}›¶Ğ¥ÿGıšénİ—Ë}\ÎUîôküßùõÒj¦£[C¡ó½-ç>!ºêÙ†&#¥ay‰lgò¬.æ9ÂNòãÂÛĞ±ç‡•“ŸíÛÈ‡—ÛZ{5boõ_ÌÜÖs¸ªÕ6/D…” Èğ~úw»şîäïÿÏ•ä²ÿËtiõtLö ¯QÍûÇ7ô|nì=61K8xõÀ,£Vî²ßÕwÈ§
+Ór£[èËh&=2³H¡‚Š3‹ac‹(»VsîM>'`şçT®Œ“cüp`Y¾¶”XB«úe'¤nÖà.kĞ²mQà`²† kş&¦1Â"rC°tìÊÎf˜Ïh–YŠ@¹6™n`)ò\adşÑ‚XĞ²°` ŒÁ‚YXğ,¨˜XD}©—…àeç[áåD’ˆ,·H§”X`WbÁ{>ÛEA$gtß¾Á¼±Şh¨5Ô7|g]œšUbûî^µz»ZUÓ0P&ò ,×"KTƒJ¸Qnï,É¬“³»´Ÿ¤ıv¿ƒüeáYÒQ8A{{‡ÈùÍœ[&hÅ›d7éâõy1CL$­vº•øI×ğ0DäMú"šñ¤œ	–Ç`	²³9òp†bä1ÀÂ0 aÀ8˜ƒç`ÀEp\ƒÌ@nÀÀ#OCYL#ëüˆv¿†”ÓšóîTp=ÁÓ™T:Úß¥*·&%Õé€§5àp¶ôµú2¢†ü·ÂjCm[üş®DØ±+–k÷%_wk½¥!^È&âGë–ñî!*²Ùc¹xë=)wpë†Ğ>€LÑ¡‡XÎ”j¢:ğ¢IÅÈ2Õ«¶õ5JôÅ¦M^C_Ç¼In½ÁîO³æáaÖX{‹¡?Ega¸¾†ÃÊ"?—1—t`ÃMØŠ:°Áÿf6Â†qØ0ÎÁ†‹°á
+l¸`ÃØ¸ZongÕK9Ïd»¥mJ¾¡îÖóë´¸~P£-Vàÿ{?o;Ø–œŒ†zGFGzC¾M½¾¦{râşø®v$§”vwËfïöIòoí£ÙZWêŞL²7ì²ZêbPkÑéméìô:S»ré|ÌmjÃ~1î1*¹Şn€çİ*¸7ÔªE\e¥ÍJïŸŸŸç­àMÕÌ]íÿú\‘µÛ”ÒáDŠ±mŠKHÇ%l*«PŞ¿(m–\a»;×¥	7a*ê’½ä`B&ä`Â L‡	s0áL¸®À„k0a&Ü€I>c³*&Ã2ò¥ün‘ÏØÔ©Öõ#ËÍ«Nµv©Ó›bj±Á¤ş=R)ø[[ıB%Ñ¸;2™·f¿Úìİto[vç&¯Y-Ëm÷2™LÔvww´x<-İİµMGöutì;
+íŞ–©¯ÏlŞÃäŒÏ—Şƒ"çÚI— “yÇÜ³4]‰íÑñ¹˜ûíoM¾¹ú"ıĞêú!æ" ğ TE_„
+&Æ²²²Ä™%T*<˜A¹šÙîÄvWÆÈÅ[=¡‚ŞÕJşgdClCDb÷ÛSéTšì~ó:ÜWøi¾ÿŸÈ}…Ï‘R#W¯•øEÆyúĞŒ?•#¦¨ÌGTr95ëVd†¿’õÂM„ŠúÁ…Â!‡Â8B˜CçÂE„p!\CáBLßÅ·*6²l[W‹Z¨Ğ°£°l¯Ša‡b*…˜UbšÓ‘&ºsò—b¤Ö¨ÖPªÓ ºº‚R•Áªïm?=ÓüÒ[;Ü-ü¸ iãµµ™xĞ`‰oÊÔÖ&B-µîİ7Uxîßú2¡d^öS†H—P)‡Jİ:7¶‘Ö*3g‡ÍWa¬&É@A"gùÈÛ]EĞ¼öı"ı)8Îâ¤Ì9ye.Ò¼Â‹¼ÈÃ‹½ğb^œ…àÅexq^</^‚·è™^¼¯ÌEº.Rƒâİâ Â?ªÊøGÚ7Y±içTvä?FÃ#ï¾øiÓ¤Ê›Œ÷h÷xÚïë:N~•Û·ÙÛ>sqçÎÇ§r—‹ŞÓVŸØu¼3;»+¡¼\{‹¾Lúÿİ9ÿ£ƒ½½;<ÅëdóŞó££ç÷6¯d:3·'•Ú3—)^›íìœ}lpğ±Ù®®ÙÇ8'é_»MågyØ_,"4ŸDŞÌN0e[ñË¶’‡y‘Gyş³yÌ ³Èãò¸Œ<®"g‘ÇKÈÌã5ä9‚yV‘¾O;F5ğ·òä~›—%4³|¨›ù´{ÍåoO-Â‚Íè•ßÊcï¨°ì“Áku¦B]ª6Q«­§GÌf&•bº*ç:uN¬Æ[Õ&o0jñ4|áùÌj—Êö»µ‰ £.Ñíu„íUNOuCg‹»:16Ğ>ÿµ?¯İ‘¬M¶†ò\µ·ŞgZêoMáÇÿKM ØâkËşiu ÖæklXjÂé:ws(h·„S=Ç–®h+i}1³Ô·¸}ñ W;Öšñ¤ÊrZ>ó”ãÂ>•å]—êò3ü÷İ%Z9Yİq›ª_²æg·ŞÏ.xõ¥gşó»ƒ…zİ·ÕiÎsÒ^~F%­5ÃSñ•wçußæ=•ÿë ·¢QˆÄĞ°?C¿j=Ô…FE¹…zÚ…FÒJŞÖ…FÕ§aTîUĞÇA¹¼ôñµ·‰
+#ôqÖÏÚ¯Ø÷‰sT‡~zDî›>ƒt	º‹ßÛMwa+Õ¢’4ÁÈ>“[0Q-Œ¼=Šª£¦¿†@{a$?‡ƒ<ŠVEb¹ĞÇ`Ï©~‰GhÚÅçãáãta'«é¿"HÏÂŸa€ü?'ä5Ò3ôyÕıj¨G4´&í€ö)Z×ª{Dw]÷sİÛ‡+®´TF+V>QùEı	ıÇÃ˜á-£Ç8kü¢q©ª¯j¥ê]SŞt¾ú@õùêO˜kÍ=æóë‹ğ×Â?X"–EËëÖ=Ö[¶—mì†~.£³üõöÏËÂ¡º‰sw€?c’šİe±ÉZP˜ø¾AÔ:PYš¢®Ôì%.S˜Ô}\6€Â¬á²±ìûfŞ~˜Ë(ôêS\¶°±ÔsÙÊ¿ó—meÏ:Êdë\®[o¯àsV?Íd#Ë†*ÔW¹¬—¿ó×‰ËOı÷â¦0‡x§°ó8…ã8„cØŠyœÄ9œÂbgàC 1.‹$¢%¹µLN•É9øp'0¥´ä”»÷ğ1çqçpÓJËaœÂ!œÂ9ø°Çqğñ9ù0‡38Í{›Áæps8„3˜æ}ßÙ_0c8`Çq’ÏcÓ8|èUî®¯õ~ŠßŸÆ)œå=Ç ‡{0ËçÈ:ÊgÂ:Æç9|„)e&½#˜åó™Vz<„)Âaã-§1œÁƒ|­¬eFYãIœâ==€#üù£ğáŒ2öee3¼6KÇ€É'øœÙèg0ÎapÌØ·.–õ$Âú:ÅñbÏÀÇ›ãë8†ÃüîQş×‡>œâsú _İé²õàHn+ÓrQOåsc«;Íõ^üë‡,ëÌÇÇ“±*Ç€­‰=õ€²¾¨¢ƒÓ8‰c¼‡bëqşÌ·Œß<‚c˜/á#ã|†Û›Ù_á)åîƒ|ö³½3eˆMã!>/†:[ÛƒÜjÎpëcÂIeŞg¹e¼ˆÊ–÷ï{a¶äm9$Êäïg
+ó
+¶»q§ùŒó5*v{
+'ùß¢/•ûÆÈßyo°–£x€ë¢<z0æ”»óÊİéÄ‰/'^Kücâİï>ü|Í÷ÿ²ìi¦³Sj¯:©RoSwª‡Ô¹ƒÙ‹ß¹w·6§iãÚíÅ=tíOĞzÇ©ìœŒL„
+!Üƒa`öbûĞ‡íØŒ!@Æ0ŠFD‘Âä¡ÇN4á^x¬©ÆnÜ‡Ax1Ğ8ØO(&`†6|ø{N¤F­¨Ä¤îsù-‰ÀNÂŞ5¡p4“oB….´¡õ°ğ4ã› Ø¾±‰Õ’j¸Yy(ÿ_	zV™4ø?#+ÍÕ
+endstream
+endobj
+
+73 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /OTRWJX+HelveticaNeue-Italic
+  /Encoding /Identity-H
+  /DescendantFonts [74 0 R]
+  /ToUnicode 77 0 R
+>>
+endobj
+
+74 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType2
+  /BaseFont /OTRWJX+HelveticaNeue-Italic
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 76 0 R
+  /DW 0
+  /CIDToGIDMap /Identity
+  /W [0 0 500 1 1 926 2 2 222 3 3 315 4 4 556 5 5 574 6 6 556 7 7 278 8 8 519 9 9 556 10 10 537 11 11 481 12 12 593 13 13 222 14 14 537 15 15 333 16 16 278 17 18 481 19 20 593 21 21 577 22 22 278 23 23 611 24 24 574 25 25 759 26 26 481 27 27 556 28 28 870 29 29 574 30 30 852 31 31 722 32 32 296 33 33 648 34 34 222 35 35 667 36 36 389 37 37 611 38 38 481 39 39 259 40 40 556 41 41 278 42 42 1000]
+>>
+endobj
+
+75 0 obj
+<<
+  /Length 14
+  /Filter /FlateDecode
+>>
+stream
+xœûÿÿÿÿÿ ÒÜ
+endstream
+endobj
+
+76 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /OTRWJX+HelveticaNeue-Italic
+  /Flags 131140
+  /FontBBox [-119 -209 983 731]
+  /ItalicAngle -12
+  /Ascent 957
+  /Descent -213
+  /CapHeight 714
+  /StemV 95.4
+  /CIDSet 75 0 R
+  /FontFile2 78 0 R
+>>
+endobj
+
+77 0 obj
+<<
+  /Length 1198
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+42 beginbfchar
+<0001> <0057>
+<0002> <0069>
+<0003> <0074>
+<0004> <0068>
+<0005> <006F>
+<0006> <0075>
+<0007> <0020>
+<0008> <0061>
+<0009> <006E>
+<000A> <0065>
+<000B> <0078>
+<000C> <0070>
+<000D> <006C>
+<000E> <0063>
+<000F> <0072>
+<0010> <002C>
+<0011> <0079>
+<0012> <0073>
+<0013> <0062>
+<0014> <0064>
+<0015> <00660066>
+<0016> <002E>
+<0017> <0059>
+<0018> <0067>
+<0019> <0077>
+<001A> <0076>
+<001B> <004C>
+<001C> <004D>
+<001D> <0054>
+<001E> <006D>
+<001F> <0043>
+<0020> <0066>
+<0021> <0053>
+<0022> <006A>
+<0023> <0041>
+<0024> <002D>
+<0025> <0045>
+<0026> <006B>
+<0027> <0049>
+<0028> <0033>
+<0029> <0027>
+<002A> <2014>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+78 0 obj
+<<
+  /Length 5905
+  /Filter /FlateDecode
+>>
+stream
+xœ½ZP\×yşÎ¹û`÷.ìûÍ¾XØå±°Ë.ì
+„xH€„À2’@É!	
+BÈ8M£´¶©‰3q%V’iµš61i3êÕ[yÒT±h&e\§©Õ­œ¨I”Ô±'QœÆb·sÎ½ d;MfšVèßûøÏşóıßÿ  Dœ†€ÄÁÙ™ ëYüÀs ŠÇ>š‰—|À¿ ôÚáÉ¹1Û¹í" |ğLºÛò£zÀo Ñüµö÷ ;€Òñ£3ì>K®şq 19upd^xØ yä8}@ø˜<6rtôÇ?¶|P_<>ubfgô™ßÊê œ>>=z¼õŸò‡@ÙW ÌÚ z±ı`Ê¯‡ªa ‹0K@¬[‚®wàË„<1(‘üãÚ}W ƒ0¼¯Z‰ƒídµ“@*CÕ„X°sA(ëÜ1ë:t.Ø9´ *ãÿïŒ°s`"¸€¾ĞBë wÕl¬– b~TÜÏ¹Á`gğaÅÃÃÜÃ¹Áørµu¬;¸ Dz¶,œn÷.´¶zC¡`ÇÂó½Ï·{CƒƒÕ4«‘ƒï›p)1kc4•Õ
+d/;N{ZÏS>ÑHháùsç¼çÂƒò•pH"P.HàÏeiíå·ZÃ!/»…CƒŞĞ`{µ]¬{ç@G»7b‘èÿç”ŠkSjˆIyJG)-úmRjü­Rjz÷”šcL,¥–Õ”¶z°šÒpháôÛŠ_›áÕ­ï’òÓrÊO¿KÊ­kR€"	oÒ @9d5‡ÌäÙÜŸ}Ü!zqùıôóËëè A/ |›.ÂˆzH q	ê¸]\âÄx* ÄliÈ¢`Õ*R¬Dmˆ„IXàßÖIYéGÈ–¹»´|2÷uï«#ZM—¿@÷.ÿ)\NÓñåO‚æïøºÈc´‚šc¡J1%j­™°‘)ë’c—Ãz¤o’Z~‹ªAÊ¿EÚég@­³1.ÁÂcUs*“,ea…‘Ç)Am’à[â~µamJ("v›Ÿ¦’éRDÂ%‘úºtÆšÊük°?¸Û´»
+Ö@¥Ëè7®B[€’ÖÃ&ª>¾;wÕ`İA«V ÛTj£MgÒ‘D7X>ØœÈÏé"øã,œ0ğPœ¦65¾nÃ :Ôæ…¸a@h€]0`LÀ€9pœ‡—`ÀpI0˜$X—$XãÌ«„ĞÈ«D”Ù{XaUIğ˜²ğ³lò²
+)k3É4“TÒa·Q-ÿ\_	—h´Që“ó}M§«#©T*²±¿E[°¹+} H7ĞÅå4ñl’p™Öî´ä^$QÚÜÑZ]M‰æüª£f˜Æ?I(K(‹K(å ‡Wf’ ¿!&	–m^h`D`AtÂ‚]°`ÌÂ‚3°`\„—aÁ5XP8Ô¦Æ·`Á-X@‡$èMŠoğÜã6ŠWr[7ŠQb4 ](Æ Š1bÌ¡gQŒó(Æ%ã
+ŠqÅ(B!9!S…pr»Ğ”¨Íp”4S¯"ê¬k¦©¤Ÿ²D†K"fÿºí©ö‡·FM´éö»“[kÃ©“»vs¼sË7â6Ó{g[&¦÷Ì6—t%œÑ´?²«+±Õ1‡P5üxO"|PÑÄ3Ä>Šˆ@D":!bDŒAÄ,Dœˆyˆ¸—!âÄ•‰¸‘gÈ²Ä`¡Tˆ9Îê×Í‡(0%jCÖ°P$pà7Óû@ì6G*™Î¤´äÓGû›´¡Ä†ÒHU©èH˜¨:÷jpC¼˜ãÁ¡%5¹—ZbÕÛ÷äßÌß!/R3Ö£›zâˆKHŞ Ê«%â6¯–7DT@DDtAÄ DL@ÄDœ…ˆóq	"®@Äu>M	=&	ö%	ö8ºINJeHBäÅŞ$£¬	4!‚&¤Ñ„N4aš0†&Ì¢	gĞ„y4á"špM¸†¦•6áš@‡²hW¼#‹.xxöºLYd áv†Wš]|X+Ê%ö„„ò%	åñD­5Õ,¬ F[$(¤“qj÷qOa%YCÆ¬ÍêLªˆh5ìV¿Ê‰»Ìe~›1X[RõPO­»²!´±×KU¥a1 /Ô5b‘(„Ôb ®=RÑÓTa"ÁdKsÆBuF{l´´L¸ÃN½Æè±{ü&­ 2„ZÊ3ac¤”–D´ªª.²XÊM¶§Ñ”ß`«lÉı,TfÓiÄÂÒv_{én3#€÷ı¿qÛ;yí7°Y83>ùkÙÌDÕËoıZ6Û
+}şù)5#ˆ*|BBŒ7”ĞjC‰™$–$â2Âp €H#€N°Œ!€YpÌ#€‹à2¸†À
+Â¸… ¯R™%Áfi^eo-¢ÜÖš²(Qºb	c£2×"*#©™fÂC5´¾®,$Cí yœj&¦ëGºªlÉşÖÊæ˜¾ß²µÁ“ˆ8ÈúÜK:l}Y8á$–Ú>’xïÖ’®QGU[U"eÄıÎ}¹Ó]Q’¿
+×¨"¢ KĞ+GÏB –ŸN±ø
+eœ)!ÖFÃoŒ-ìyì•ÃŸÚv€Xr¯½ôõÜs ù¥üzZLÍp¡œ!ªH¡¦"QnÜ†{QnşU7àFÜ„pcnœ…çáÆ%¸qn\‡›#ªRFÓ îÚÊkUF’ß$!b’àº!#*åd’gÈp¤–ù‘c*é›ß™¡ÚpuÊÙ~¤+ê©ëNÖmP1{êzR-›¼©DgU/§‰Í¶4î;¹>¾m] 4¹õ…ª=[ã={z’[WêHÑ=¢‚p0–RÖ~¢o5\ºÈzƒ=‡Üáõö”„à}âHBĞ$A·ÄdZFEŠ±ÉpLºà€¸†pa\ƒ³pá\˜‡áÂe¸p®Lºp.PÖ­J³œ©à»§©nÈ¥jº‘¨%©"‘·UòŒ‘Ïõ‡:t•yxï£Î~Ë¶Li­¿Ğ“ê®M5’‘½ıõƒÓÍÏ<4ht•§ı•»;cõ«<ó(µÂ-ÏŒ'^ñ™f²$™ˆF^£ÃGúj56³-6ÚLÊVPTĞ6ä§nVè·|›Ü˜NEÈ^J;ë§˜ï7òÇ0)Â	<÷YP¦k9r3ÚT‘`$ÍB&êZ§Ö›Ü6}]CÀ¨Ÿš2½V!¡JuT€ä¿š“ÿ¢j8c¨İÌreYUÈ²•¨u2m,„­ZÎõQ­Ÿ0¨}ìz™6íİ[g,õé‹õFCĞLD‚»éC¹Qòéå·úİM‡FkU³Ø™¿C$ŞW¿œE A¾$S•°s»R®;nÃ¾R9v¸aGìh€]°cvLÀ9Øqvœ‡—`ÇØqveØQÉÅÅå¦M‚ğ+b\Bİ…npÖ*[e-¸­QÂ„_€#EélŒ³œ~AO54^W54Z#¬`ç`I¦³´´#rFk=îÚˆË^Ri÷Ö–Ùi_0ÓSénŠ¸"ìNÔi”[«[ÉÑê–¨ÙV¶®Ô¹ô¢Õáµ:üÖ½3ZœÜTn6G6Tù«CQoux,6·QSÍö ù;ÔKáB%Nş_pPLVèkyg-ÉØ~÷D½d-÷øé“óİVªòU7•ní,u'{êÛ}4óo®DgMË6Wªw?æ32æØo‹ø­ééÉ¡Š2JÔ¹ñ²][í*Ú–r–§½¾Ï¹sY¸QÄƒqËªÓÜˆÀ4Üè„»àÆÜ˜…gàÆ<Ü¸7.Ãk|šœ;Ü¸Å“¥pnVî6bbÁÏmİÎeê3\#ÜëcLv–ÉË¯Hkòõ§ú2´ ¤:é’I·§–“nî§÷‘îbî'°]·Sn&^¥Üò½2å‚ 
+ĞôET|ŸÎ0FI%N-£0‘¼ã³–íi/|m¨h·i·¹hW§Á/E·ˆjM_{ÛçC¦CCı$›ë$ÙîZÚTª­*ÁU²eÙëäzàüÃ¸Ÿ•PÅY'uM¹¦¦¦@° —é"×ê¬ÇÊ=—åTÕê„‰Îmj&{åŞxr”r7I€üyî"ÙÃtøóqZNÍ¨F:˜ˆ+"‚uŒ0Jx5³ms«bÊùmŸ)=RÜÖ›²X·×›µeÖ°6\ÿ¢9Ù¢†FÃÃéL3¹ok(ù‡¡^Õªë}-‡:ÊÜ‰®Dm_1Õ;Ë[j]5a'í#áu]å}³!Ñ–û3WM{õ¦6gÍæD00u“ì0uE½Æ†½ÓñmÒJén,ÕZCªËÆmŞ®gKû»’[7DwoM8#ìØ ıUÿoÎ3[sÆNYSVòS">ô5êŞŸ¥Á=ö\¡ªf-“4y2wLÆX¥¢“´|İVÆÅšñµ)¥ü#	<ôï4¶g+Uçv/-¿Å´@Ş ‹PóÓù=¢ô]¶â¡LÈza¼lÎıÑc¬Ö{é£|\- şç7òI ›ïŠUtßé@ŠÜ)+;Å¹0¿÷}th/™¤Oî}ê±Ügé0×$ïYşÿ^\şcã6ôÃtZxßqz#oõ…¥D-É„´Ì3}¯eùyóëg†ÏĞG{{—Ï°ày¯üÔŒ4>Ê(C–™}}¸ß
+ûúà†ğ¡>tÁ‡Aø0æàÃYøp>\‚WàÃuø8ûúLJ–$”ÄeâY·²§0Å%„âYÔ*¬\Ëä”I‚gI¶«–Ş¾ÏĞÈÛŒØ÷>®P6'm43q´¯±Àæuv„Ãe:msƒÖfı%e–’jµ°¥¿M­wUÔyë†ıbgmz(D­|GbŒÔ{<å¥A]?÷2CMÎ"ÕPîC†œDÒFg0æ-LU¦*k+é,÷‘üëôoéwÂØì²°([›1;Y’PÌ` +BĞ!ÒĞ¡:ì‚cĞa:œóĞá"t¸®A·Âê:Ü‚NV„*4²íŸÜ4œŒî×}ö{­©Búñaç±ôƒu²­SİÛWvlÜûähú³{ìÂıC%vÕµ½ÿPËÎ¾æ¡Í\Øı‰ÏŸå¸vd†¾7ä6IQ™$‹@Æšsk²­VV.•	ó¥rfdªkOíï>TtP«³–t6±È\jI5Íú£Bİ®š2§@·¨…pÃÖh7‹AŸÓï¢_È"¨ìƒ¦,ª”³š*«Ü†c«¬:Pà@„p`œ…çáÀ%8p\‡CÑ\T½Ms…\Õ\iEsµ1¶ö*
+ÂË5×zEs1•¾§³d­ĞÒÜZq²¢´ü”j‡iÅ–áúÄPW'ÖñÔ„md[¨jKÊC‡ÕÑîÉÖÄÁŞ”/ÑÚïª
+X‚µ²æ*'y³iWÆë©{ ®|}•OçÑZ¼Qoi]Èd.ß˜Ø8ÜäóÔo_—ØXåå·Ê<ÁXqaQ¸q%ÍŸÍ¯Wö@v89{05şó_­Àµr:³rTÅÎ‚_5¥Ö‹Ğ\£/²˜ÙÉğre·ŠÖ'èèò«ŞˆCÏ(4¿Ğıœ£D”­9+elU A9co…u$•	9SaÌ*·sâ}¤:tà¹»Wi=ãÁo›.æ†Èƒ¹/3|xğé!ÍoëçVm(Si"%&ÒÜÛ»ÂÑô]ä{èµ¼ÎŞ‘&‘zõtó½òõ™§È–Ü±:rÂ”{"A>lâôÿfï÷z¥”.Â€êwôwò¾¸–÷[ˆ•mÓÕü8:6:|úæTî.dş¥½¹ÿ$WoRòŒÜß´ î¾ë¾õÂüğš}+òw¨@ÿiÜÉÂ¤ğ’ÉÄ”¦|dæ–kFƒÛĞ¬ÔTğ„]Ğ`L@ƒ9hpœ‡— Áhp^3Iö¯dœûLâ6’+>“p#‰
+$Ñ€$ºÄ ’˜@sHâ,’8$.!‰+Hâ:’¼g„ndQ3BÜï:Vm¢¢DS¥¨æv)_;²ºvÅ÷òª]=æuçP£Í‚rp£M±¦"?tËlIÜUM¥•i¿ì!§&6îo	”×¹jÂ©}}%š=ºî&GU‰½´¡ƒ|¼]ãª©(m,wxcë|§¦ª;v–%zœZ_e}`ÏîÒ¦cİZ{$X“ö²Áä¼È×ÍËkäUŞX»æ”ù‰vº˜Ë*¿w¯	ÃïŠí÷šè÷ïa›üÉ—†Mwˆ[ø!{ıò¦_²ßßâ{×¾ø±»\@ıU=(k%ìªüğ7ù*«oÜä¨ üßÂÚUäçH
+ŸA/^Éß%ë¢±ü]Ú3ÁH Õæßä×ÜĞ“›ù«t{~‰=Kİ°“òw‰#ÿ¹™ÿ*¹™ÿ%İ¿K·ÃLÛ%éAl¤ÍùÓ7QAn¢’Æ Æ ¥Íhúòwé‹ˆr8é¡Ç+ù³ôÓùEò8<ô ´äfş. ¥1€8ğ„ğCáô½ÇñI“—h3m*…§UÕÕ7U¯ª÷©?¤^PßÖ|\[¤ı öÚW
+hÁïd¾Sğ]R×§{]@ÿŒØ+>&~E|Aü…¡ÒĞ\¨),)LóüVñî\ªdÏÆ~ÅG¯ò»¼ÂNáT*P®4™­…*nk×Ø:@U
+“bSTuÜAaRµrÛÀí^n›@Q¤ÚÏmö»½ê·-ìÌDõ·­üö× De[3–ƒ_‚ÛnPXTOsÛwï™³êKÌ6îó/¹­çïfGŸşÔKèÆILã&0‹M˜ÂqÌa8ŒqÌ ˆrD‚¨EÖ¡±U;¹ÆN­±Äár¥A¹Ûƒ	Ãf0‡ãU®À4F09±Gq [Ä¦Äfp‚{Ã&0‰	Œ`£Ü÷ÛıUcF1‰IqS8Šã<	ŒâjD›r÷Şü˜÷i~Ó˜åk ‡}ç1âÏ²HFøÛ,ÎQã#R"9ŠÄ8gTñ8‚CÁLò+'0…1ÌàŸ+»2¦Ìñ8¦¹§“8Èß?Œ f”±û”™qÿ,Ê Ï³ñ˜Ùè3˜Bs˜ÂI3öËË©5äQ˜¯i/–á1yÆ&ø<&q€ß=ÌÑiÓ>»kæwŒgróšU^Y§µ±±Ùàë¾òóÃF–×,ÈÇ“sµ6lNì­“ÊübÊœÀqLr+Wòw&82îò &1µš9Ï3g,²1>Ãiåî)ı8ÏŞÌšŒâË:›Û)š>–WâåÈø]dTFŞo®Âu«ÕÖ€Ä;ÅıÂ”’Û˜Ã	ñQ>‡.·Ó8Î®ÔÒÚÚØq_mìxGmt)•ÀVúw0ö˜Xsï=8‰Q>“n™J<“¸š¸ø»Ä³_ŸYúş•/~ã+Ø´ú>Ã8{û¦âyJåQmRµªÚTëTIÕU·ªaôéwj:4QMDÓ¾æÍYŒğ¿É@şç@şiö·ïò¯
+@#z°İØhÇvlÁ^ìÄƒèD?Œx»ĞÍ„ÂŒ&lÅ"2èE]Hã0v/Ç6Äà€¥=yl¢sc"!A_vÒM`¨"LÌ¸
+ÚPJøaa½¤ê*ÔhDeğÂÄ¯à*(:ĞÀ—Ñª<$`Z‘D)òCl¢‚™iwùÏc$>§ÿ•¹p&
+endstream
+endobj
+
+79 0 obj
+[/ICCBased 81 0 R]
+endobj
+
+80 0 obj
+[/ICCBased 82 0 R]
+endobj
+
+81 0 obj
+<<
+  /Length 258
+  /N 1
+  /Range [0 1]
+  /Filter /FlateDecode
+>>
+stream
+xœu±JÃPFOŒµUªv¬DœD@¤`]\Ú
+F§ëMkŠIˆ¹‘RŸB|êê&Ø¥n‚à¤‹¸º(¸H¹rëTÅ³üË9ğ`ùÕ¨a”&åÊº»ãî:Ùl
+Œ3Å¬*ŞªnÔ ”h)™&C|>b™û°ä‹ÈëŞìçº«é»“æõAçívØıCÆ«+	ô€y')ğ
+ÌµÒ8+¤/<°ŠÀâa­RkpÂàØ´óA¾mWÓQ”IhÿãŒœ%–Álş½E5VW~ªüdµşX€ì)ôÏ´ş:×ºöôb‘ˆk#&¼_Â¤3÷0±÷ØIì
+endstream
+endobj
+
+82 0 obj
+<<
+  /Length 314
+  /N 3
+  /Range [0 1 0 1 0 1]
+  /Filter /FlateDecode
+>>
+stream
+xœ}¿KqÆ?×U–X94%MQKS†Nø#Ô¦óüQ vİ÷BšË¡©hˆFk	¢ÙÆú‚ !
+¢­Õ †’‹¯ZPÏò~xx^Ş—”ç¼QİŠ¶ùµx"©¹^PñÒÏ cº!ÌåH0
+ ô’0l+Ï½ß£Èy7½®Ó;¯×«É¥º;Q?V.ø_îtFÀà3LËEÆK¶)y	ğëz”80eÅIPö¤Ÿkñ‰äT‹/%[Ñp ” å:8ÕÁ…ü¶¼+%¿÷dŠ±ĞŒ"ÂÿG¦·™	`d_¿{Ù¹ÙÖ–gzçm\‡Ğ8rœÏSÇiœúµ­öşfæë ´½Ô1\íÃÈCÛóU`¨ÕS·ô¦¥]Ù¨ŸÃ@†oÁ½öãâ_±
+endstream
+endobj
+
+83 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+    /ColorSpace <<
+      /c0 79 0 R
+      /c1 80 0 R
+    >>
+    /Font <<
+      /f0 61 0 R
+      /f1 67 0 R
+      /f2 73 0 R
+    >>
+  >>
+  /MediaBox [0 0 612 792]
+  /StructParents 0
+  /Parent 1 0 R
+  /Contents 84 0 R
+>>
+endobj
+
+84 0 obj
+<<
+  /Length 3940
+  /Filter /FlateDecode
+>>
+stream
+xœÍ]YãÆ~ç¯h¯İ±×=}7™¼kH€ì¼Ù~Ø™xb³ZGVäß”ØdW±ŠMI¤ä—¡Ä¡ú¬ª®úêàí7Ûİ/ïvâÕ›×Õ¿+-”PâËö#ŞW·J<üViñÛÃ¦jÿù¾
+Ú%ö×ö©§êğôSõsõXı½úîÍëêvFÃºmXÉFé&¨Z(iŒõ¦qºıWMm²ncûŒxÚ_›Z6Êí{î?f¿ıõİF|õU%Äí›×şV¨êë¯Å«oÁ@š ¢k¤³a4ÍWw•wÛêöQ	Äİc>|%îŞWß¿øA)õƒRº»šîj»«ë®¾»æ~¿»ßÿİg7‡oúğÄ#xâpo›ıgÔƒîzÖ]O¦ıŸúawó£¸ûKõİ·dšY2ÕHÕ„lÛİŠıF£}¨ƒCë¨…V‹®cÌÖ+=µ#ÿg²UÜM÷Ö8µ³­ĞÂ–^ãÔ¾Q7Bk-^ä›nªÆ ‡»Á‡îwS7æFèµ•†Ó]MÌI¦oÁ)tƒ´Šxv{#|D}t­Ø´E´óX"$C’«EQêÚIàZ*ŠµJ:•¯k+”ôqaŠª§Ê¦Q[x¤‚ÖÉ:°šñúuëÖ˜ŞÍ^N¶+à•l†xı¶(ß¾şkeÄ+'Ş$QÜ^ª·sº³FF´àM¨CÛº ?d¯ï+%´´Îjçcö©ıŸ•×íõ©òÚÉĞ²¿PÂë=Ù~³û'ƒ°VÖÚîÂzéBS{#†Û° mµûøPõŸª¡Õî–ÊZQ©ù‡©óÀ4éktQ»&‚ER¶ÙµvWèÏøÌ¨¥?GØ!š‚"?=£2O€ÿ$©‚d8~†§<u—;Ò’,JòÂ@9ÓÏ’œ‡§»¢®›'¼›ZˆğÙ^hĞÃ–\ÿéCb{èE¾EcF{šdÜºçî8:<ûÔ ÷7­½'gvÛ†ågOîQêÈÏY½ò´…Ï¦\!Â{°Açl’ç£>K'šc¤‡ò²‰zeÙa‘VFm*'h)—é‰´€ÛE"‘t3^Ïııg4;D dcF,ıøt~ø¤Ÿâ§lRCI=@(‰Z‚ìˆ™“âş3B.Àùéò<ÀÚq{Z]óAK×(t4–M7`J‘&À°Ÿİˆ»MŒ*£ŠJøàdS×ÊÉtMézœfºdSMt‰.˜}APC {CµDŞ%jíÅ6>Ü¼v ó'^)Ú®3„nd(ÀÙÔën?%‡¥<×/Ø~A>sï¥‰ÖÌDmÎø3gé™î'*
+<ØPsRÇEÆ¦¹±õL˜Îz¾‰ßŸBz8ØÀ»é,ët“AXGÄp¨µş„zÉ.ZØ=œ{f¡?uÓyŒÕ#xZ ³ìhê}F³u÷P¥A#
+h3!J/@ÀXS˜–‰Zzw-..¨a¤	²qkÎ3
+êQF³@æÄ„N‡'hzM÷!6
+‘á®Îô„Hàpæ4ö0{W(ü@7^ª`ü"{3Mè%mISŠniìBã;UZßK,IÍ¤ô 5  î‰Øá;’Ìí¯LúÕ#'µ‹íöÓQºp.PT\D,G°¢d(á1O¦+F©û^(€9£É€BËßŒPìèñaé0ÏhS¡¸Mœy ”4!Œ1uZ@$
+4jëŠŒÅîh©šQğÑ¯Rx„Ğ¡‘8R!$|ZÇJ­æóÄâaë ¿¤Q“¤gÛdÓ+Ş×ğ×PmòŒ	†f×“çhöErel×è–<W"WHi²$hÓ“É#Ÿğ6"ıA€sàºDt‘Ş¤Å¦ö±4sÌàÙÜ\Øú6·¸i”]æjá|-Û¬‹|R:èI›L	ÌàØ^Ç,~yü%-@rŠ’cIs~…Ü—ö¡ çöÛDIÉH/P_RbhˆC%*³üñ[t“*f+½’Î¬pîç³ğ
+£™·¸h¯XÃ"KîdÄâ(%)‰Aè›E C,ñÖhÜ‚
+€šH‚&t¹“ PğOˆÉ‘Oô32ÙîçX
+óµ}C™u&XÙ(r.Á†²êL¨¥ŠşªÍa[ågÌ+gœ´ÍÚ“9‚iìhŸĞTÕ­‘6ŞÅĞœÀU#M+íÊZ4 2gk(“J7Zš¦¥¶6è<ˆÃD‚qa¡ñHw‹‘U°9Y.cÓßä®Á_ƒà¢¤"0Ş§lôï€C×€˜½EÎP\9F5·M”Qûµ0	ñÍ<ÏÎ2’Fàt
+n JC áÆÜƒøÜİïn)_½4t§Ï£½ófzNÃù³å–Ül`shSw°Œ‰aëZÖ+ÂdPKÈö˜Cû° åÛ!ˆ İí©¦¾¥,Wëƒ´õJ%íÏ2 ëY£°Î…íÃ´î0p.ë–2µAøWïéo¯È‡ŞÃÈ88†
+pHûKFşÑÜ1üyÉÄ;ÄXÄÁ˜ø Y¤.Ël¤‹²«b6}Èf	„,z
+8`3Y«¥5úŠà€õ,8°ÄàNÖI-	è¸ éAX W¡F‡5ëÚğ†nç9tÎštI|œƒ‹q>“Ùñ‚İÎ¹y…¦ßcÿdÜÇÈ-WT³-em™dÓ:l×g–âáCY[¦ÖR«…Æ·Bì„elk´¬İªÃ}>^âáC‹âkŠH™‚üÁ }¤Ï	*
+~Hî$}…¢ß{N`rŠ[HQFGécô‹läy(„#ãŒ–Ñ-4¾“Ï”ËF‡¿M"IÀüDTŠ$¨JÏ8¬6Ò†ñ(XI¨kb´ÅäPŸË!—Œ×æ`IC†ŸÃPíÄCÅEdLÓx©ƒ]j`<²ØpïÔ‡ÆôG“É•ŒÅs0Qy¢V&a‰5İIğJ·+›ï³ 	ÎKGêf)úÌëÙTÜµŠP*@˜§1!Ç?¦Ò®‡Š°%ktç +Ï[OÂÅ% L"«İÚ)¾t–Q‘µáÒIóSâ{¶€	ƒ9‹†`TÜ65ê=‘¿‡ó	cŞ•Diåi2ñyêA‘Ø·©ëçM` (Ë¹,â.rã¾z„£Ì
+ëÔÕ!úÓ€v1„>ç—+%Ø]bNG‘Şûû_À1a¢SÊ(<ffhaŸÍŠS¥µ¯1íª+e›x]KİzH¯Ÿíà)ÛÄ›V¯^h|ğš“
+i§‰wìğgÀ¨#ì±Ä¿·çZÍ® MÁ‡0gšœ±µt™ •¿‡”
+O)®®QÒ´Ñ7×L©`¹	Ò	tš6ôå1¤YÜAÇ1çE’%0¾gàÌdQ „Ğ-äS\@V_3ácR…	‰XäeyØ¡ı8!³€ód‚‘&h¯ÔC%~vªÀ" áÿÛact=’Æ64àïÙ.#şSDE…m/L.crÉ ¢ƒ¿½H›œ±nÎœ<,ÚtôMFô
+$ ¤‡²•ïIF»uóJ¶‹¯¹m\?a é)ğİgÈnGîihÇ¯_!¯ŸÑ³ï¨BƒšQ`”8pF)–,*g³+(ø†ÛüK¤ ªÄèğ†á!EĞ (n‚WOEš®š‹€edîÏ/°˜l‡zŠğYf 8±\­9U!ˆUÈ‰,¸>¹“'ãTŞq¨Å=õ;œ#×¾È†ã‰ÕC¸K E°<qÕ î1%c×hÈTd 8Ï`Íd¨òüˆ"Ä1 jzŒ"	İÍ¢Ó—“Dz2¿‰š¬ÀfÛDó{HN”%çm›©³ĞøN‰Õ—šUü/‘Àq"+3? È§Á‡Á%¾Dµ*Æ1iğ>
+ê:µœŸZ Š—À`ƒÁ5nGa	Y„Pi‡9WËª™
+Ï)añzÀVß‘°>Ïm?Ãê§‚Õ	-ú5¡C…p³èS­½¶èÄ"ƒ°µ]g¡^&I¡r±¡3CF(Âœ,˜ekt pí¨DŠûÓ³| Õ M	em™UîÓï‹tA¯®Æ5ÒÕ4g÷ZÏÍ8ÁvOj©ö~øüˆÂáÆiu(²/^7u;½¶~wË	Æ†öã~ºÁîK‡+éAñp%´i¤
+s
+ˆks~}pWé×Eı¾gÎïÙë ıÌJí‡UÖ5—îV×J•¹xÇŞÉÆ¸/Ö±i¤ÑVé‹w¬¬ôJ18ëwì­0&B‚>ò,İX„ö2êÃ›_úõö#‹P£32g^À2ùš‡¾~ËŒJÑåàse°¶ç®¤3í;ö×c×’‚µ={1¿dN¹e¦Êˆc´–‰¨+Ö÷¥€*_İ ‘t¢¥Yš¹ìcÓBèâÉ2ö"cV”ê(ø¼}ú›ià6“m¯YÎI(À5jfÔyÄ!·À‚Nù©RtIÑ| ãeÊdÀ¼@t¦-O]Léawâ-y£ÜõÇ+‰'³‘LÑÃfTG‚…)Ğè¦HD,à41U†™•®ˆİ!!*0—òÎ¹ŸG»¡]‹Ô¢•h×ö„»ÿê‹ãá®?àÊÅ-Ë!òçˆ}b™‹Y_;Rû@qHú(ïÌ·«}JøÄ§Nq?k†ş4Ò—ßÎÑû¾hÁaZ-N¦áˆó’³Áş´ùdÌoÍÄE`4;Î•I` i´£\é…t*l…ù²ïĞ0jÅÔ2:‡ÔÉc‚†LéµBó2Ê>Îâa®—c¶TªÖ¡¥ŞëÏ)F‹pß}‡7'8Æ…!¹e#C®©Ä¬"éÌ~ƒ³§j¯O#İ#G ¬Ôİ£²-€~ä6es)=ù&L3<~Cq8i*İü„Šâ‡«{Ö<…¢Ïp‘qøo`›Ã¬¾ÙíŞ=üüÓ?Ä÷·¯>ìvŞÿØŞ}ûŸûİÿ~ıIÜşéÃ‡İOÛöÖİşûßŞıó—Í»İ/6Œ¯ÁKÓŠqˆN;¡È®ìrM¡62êº- ƒk8İ÷Zö¬_éı¨y‹@:cÁµ˜É:tÊMİşÙ?ßä·ÿ€¸#õãF¿eJÍ“ù6hÀ4ÿˆxj›+½ı'/7	‘bSëÿlCÑ
+endstream
+endobj
+
+85 0 obj
+<<
+  /Creator (Typst 0.14.2)
+  /ModDate (D:20260420093149+02'00)
+  /CreationDate (D:20260420093149+02'00)
+>>
+endobj
+
+86 0 obj
+<<
+  /Length 996
+  /Type /Metadata
+  /Subtype /XML
+>>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-04-20T09:31:49+02:00</xmp:ModifyDate><xmp:CreateDate>2026-04-20T09:31:49+02:00</xmp:CreateDate><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>ne1GG93lZsQgWWLwnkXLOA==</xmpMM:InstanceID><xmpMM:DocumentID>ne1GG93lZsQgWWLwnkXLOA==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+endstream
+endobj
+
+87 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+  /Metadata 86 0 R
+  /Lang (en)
+  /StructTreeRoot 2 0 R
+  /MarkInfo <<
+    /Marked true
+    /Suspects false
+  >>
+  /ViewerPreferences <<
+    /Direction /L2R
+  >>
+>>
+endobj
+
+xref
+0 88
+0000000000 65535 f
+0000000016 00000 n
+0000000081 00000 n
+0000000307 00000 n
+0000000895 00000 n
+0000001024 00000 n
+0000001111 00000 n
+0000001323 00000 n
+0000001404 00000 n
+0000001581 00000 n
+0000001758 00000 n
+0000001842 00000 n
+0000002021 00000 n
+0000002200 00000 n
+0000002284 00000 n
+0000002463 00000 n
+0000002642 00000 n
+0000002726 00000 n
+0000002905 00000 n
+0000003084 00000 n
+0000003168 00000 n
+0000003347 00000 n
+0000003526 00000 n
+0000003611 00000 n
+0000003703 00000 n
+0000003803 00000 n
+0000003968 00000 n
+0000004054 00000 n
+0000004133 00000 n
+0000004277 00000 n
+0000004356 00000 n
+0000004497 00000 n
+0000004665 00000 n
+0000004751 00000 n
+0000004830 00000 n
+0000004974 00000 n
+0000005053 00000 n
+0000005194 00000 n
+0000005267 00000 n
+0000005381 00000 n
+0000005549 00000 n
+0000005635 00000 n
+0000005714 00000 n
+0000005858 00000 n
+0000005937 00000 n
+0000006078 00000 n
+0000006246 00000 n
+0000006332 00000 n
+0000006411 00000 n
+0000006555 00000 n
+0000006634 00000 n
+0000006775 00000 n
+0000006941 00000 n
+0000007027 00000 n
+0000007106 00000 n
+0000007248 00000 n
+0000007327 00000 n
+0000007467 00000 n
+0000007608 00000 n
+0000007692 00000 n
+0000007776 00000 n
+0000007860 00000 n
+0000008026 00000 n
+0000008753 00000 n
+0000008843 00000 n
+0000009092 00000 n
+0000010525 00000 n
+0000017720 00000 n
+0000017881 00000 n
+0000018703 00000 n
+0000018793 00000 n
+0000019036 00000 n
+0000020557 00000 n
+0000028400 00000 n
+0000028568 00000 n
+0000029217 00000 n
+0000029308 00000 n
+0000029561 00000 n
+0000030840 00000 n
+0000036824 00000 n
+0000036860 00000 n
+0000036896 00000 n
+0000037254 00000 n
+0000037676 00000 n
+0000037987 00000 n
+0000042006 00000 n
+0000042132 00000 n
+0000043217 00000 n
+trailer
+<<
+  /Size 88
+  /Root 87 0 R
+  /Info 85 0 R
+  /ID [(ne1GG93lZsQgWWLwnkXLOA==) (ne1GG93lZsQgWWLwnkXLOA==)]
+>>
+startxref
+43434
+%%EOF

--- a/worker/index.js
+++ b/worker/index.js
@@ -27,6 +27,10 @@ const LEAD_MAGNETS = {
     fileUrl: 'https://elliotbetancourt.com/resources/files/ai-systems-checklist.pdf',
     description: 'AI Systems Readiness Checklist PDF',
   },
+  'ai-agent-systems-audit': {
+    fileUrl: 'https://elliotbetancourt.com/resources/files/ai-agent-systems-audit.pdf',
+    description: 'AI Agent Systems Audit PDF',
+  },
 };
 
 export default {


### PR DESCRIPTION
## Summary

- New lead magnet landing page at `/resources/ai-agent-systems-audit`
- PDF added at `site/resources/files/ai-agent-systems-audit.pdf` (5-dimension framework, 1 page)
- Worker lookup entry added for slug `ai-agent-systems-audit`
- Friday blog post added: "The Post-Subscription Agent Economy" (2026-04-24)

## Week Arc Context

This ships alongside the Mon–Fri LinkedIn content for the week of 2026-04-20. The audit (Thursday's lead magnet) is the diagnostic version of Monday's 5-shift infographic. The Friday blog post is the long-form expansion of Tuesday's Anthropic/OpenClaw news commentary.

## To complete before merge

- [ ] Review landing page preview (will be auto-deployed by Cloudflare Pages)
- [ ] Verify PDF renders cleanly (check at `/resources/files/ai-agent-systems-audit.pdf`)
- [ ] After merge: deploy worker with new slug — `cd worker && npx wrangler deploy`

## Post-merge checklist

- [ ] LinkedIn reply templates ready (see `output/2026-04-23/lead-magnet-package.md`)
- [ ] CTA keyword for Thursday: `AUDIT`

Generated by Loki content pipeline.